### PR TITLE
fix: Use unpooled connection for Prisma migrations to prevent P1002 timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "prisma migrate deploy && next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "db": "prisma generate && prisma db push && prisma db seed",
     "db:reset": "prisma migrate reset --force",
     "postinstall": "npm run prisma:generate",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
 		seed: "tsx prisma/seed.ts",
 	},
 	datasource: {
-		url: `${process.env.DATABASE_URL ?? env("DATABASE_URL")}`,
+			url: `${process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL ?? env("DATABASE_URL")}`,
 	},
 });


### PR DESCRIPTION
## Problem
`prisma migrate deploy` was intermittently failing during Vercel builds with:

`Error: P1002 Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369))`

This happens because Prisma Migrate requires advisory locks, which aren't reliably supported over Neon's pooled connection (PgBouncer). This caused random build failures requiring manual redeploys on nearly every PR.

## Fix
Updated `prisma.config.ts` so the Prisma CLI (`migrate`, `generate`, etc.) uses Neon's direct/unpooled connection (`DATABASE_URL_UNPOOLED`) when available, falling back to `DATABASE_URL` for local development (Docker Postgres has no pooler).

- `migrate deploy` now uses the direct connection for advisory locks/migrations, avoiding PgBouncer issues
- Prisma Client at runtime continues using the pooled `DATABASE_URL` as before, unaffected by this change
- Local dev (Docker) unaffected since it falls back to `DATABASE_URL`

Also added a `typecheck` script (`tsc --noEmit`) for convenience.

## Testing

- [x] Preview build passed without P1002 errors
- [x] Verified `npx tsc --noEmit` passes locally