### PR TITLE
refactor: replace AnimalArchiveReason with OutcomeType and drop PersonType in favor of Partner

### DIFF
--- a/app/(publicpages)/pets/[id]/page.tsx
+++ b/app/(publicpages)/pets/[id]/page.tsx
@@ -36,7 +36,7 @@ const Page = async ({ params }: Props) => {
   const currentUserHasActiveApplication =
     currentUserPersonId &&
     animal.adoptionApplications?.some(
-      (app) => app.userId === currentUserPersonId
+      (app) => app.applicantId === currentUserPersonId
     );
 
   const isLikedByCurrentUser = animal.likes && animal.likes.length > 0;

--- a/app/dashboard/people-directory/(table)/page.tsx
+++ b/app/dashboard/people-directory/(table)/page.tsx
@@ -38,7 +38,7 @@ const PageContent = async ({ searchParams }: Props) => {
     page = "1",
     pageSize = "10",
     sort,
-    type,
+    account,
   } = await searchParams;
   const currentPage = Number(page);
   const currentPageSize = Number(pageSize);
@@ -48,7 +48,7 @@ const PageContent = async ({ searchParams }: Props) => {
     currentPage,
     sort,
     currentPageSize,
-    type,
+    account,
   );
 
   return (

--- a/app/lib/actions/animal.actions.ts
+++ b/app/lib/actions/animal.actions.ts
@@ -18,7 +18,6 @@ import {
   AnimalListingStatus,
   ApplicationStatus,
   IntakeType,
-  PersonType,
 } from "@prisma/client";
 import { getAnimalSize } from "../utils/animal-size";
 
@@ -103,7 +102,6 @@ const _createAnimal = async (
           data: {
             name: surrenderingPersonName,
             phone: surrenderingPersonPhone,
-            type: PersonType.INDIVIDUAL,
           },
         });
         surrenderingPersonId = person.id;

--- a/app/lib/actions/intake.actions.ts
+++ b/app/lib/actions/intake.actions.ts
@@ -7,7 +7,6 @@ import {
   AnimalActivityType,
   AnimalListingStatus,
   IntakeType,
-  PersonType,
 } from "@prisma/client";
 import { redirect } from "next/navigation";
 import {
@@ -125,7 +124,6 @@ const _createReIntake = async (
           data: {
             name: surrenderingPersonName,
             phone: surrenderingPersonPhone,
-            type: PersonType.INDIVIDUAL,
           },
         });
         surrenderingPersonId = person.id;

--- a/app/lib/actions/my-application.action.ts
+++ b/app/lib/actions/my-application.action.ts
@@ -33,7 +33,7 @@ const _updateMyAdoptionApp = async (
   try {
     application = await prisma.adoptionApplication.findUnique({
       where: { id: validatedApplicationId },
-      select: { userId: true, status: true },
+      select: { applicantId: true, status: true },
     });
   } catch (error) {
     console.error(
@@ -159,7 +159,7 @@ const _withdrawMyApplication = async (
   try {
     application = await prisma.adoptionApplication.findUnique({
       where: { id: validatedApplicationId },
-      select: { userId: true, status: true, animalId: true },
+      select: { applicantId: true, status: true, animalId: true },
     });
   } catch (error) {
     console.error(
@@ -256,7 +256,7 @@ const _reactivateMyApplication = async (
     application = await prisma.adoptionApplication.findUnique({
       where: { id: validatedApplicationId },
       select: {
-        userId: true,
+        applicantId: true,
         status: true,
         animal: { select: { listingStatus: true } },
       },
@@ -387,7 +387,7 @@ const _createMyAdoptionApp = async (
 
   const dataToCreate = {
     ...validatedFields.data,
-    userId: user.personId,
+    applicantId: user.personId,
     animalId: validatedAnimalId,
     hasYard: hasYard === "true",
     landlordPermission: landlordPermission === "true",

--- a/app/lib/actions/outcome.actions.ts
+++ b/app/lib/actions/outcome.actions.ts
@@ -10,7 +10,6 @@ import {
 import { Permissions } from "../auth/permissions";
 import { OutcomeFormSchema } from "../zod-schemas/outcome.schema";
 import {
-  AnimalArchiveReason,
   AnimalListingStatus,
   ApplicationStatus,
   OutcomeType,
@@ -22,26 +21,6 @@ import {
   NotFoundError,
   PreconditionFailedError,
 } from "../utils/errors";
-
-// Helper function to map OutcomeType to AnimalArchiveReason
-const getArchiveReasonFromOutcomeType = (
-  outcomeType: OutcomeType,
-): AnimalArchiveReason => {
-  switch (outcomeType) {
-    case "ADOPTION":
-      return AnimalArchiveReason.ADOPTED_INTERNAL;
-    case "TRANSFER_OUT":
-      return AnimalArchiveReason.TRANSFERRED;
-    case "RETURN_TO_OWNER":
-      return AnimalArchiveReason.RETURNED_TO_OWNER;
-    case "DECEASED":
-      return AnimalArchiveReason.DECEASED;
-    case "EUTHANIZED":
-      return AnimalArchiveReason.EUTHANIZED;
-    default:
-      return AnimalArchiveReason.OTHER;
-  }
-};
 
 interface CreateOutcomeIds {
   animalId: string;
@@ -75,11 +54,10 @@ const _createOutcome = async (
 
   const { outcomeDate, outcomeType, destinationPartnerId, notes } =
     validatedFields.data;
-  const archiveReason = getArchiveReasonFromOutcomeType(outcomeType);
 
   try {
     await prisma.$transaction(async (tx) => {
-      // ATOMIC UPDATE: Attempt to archive the animal first.
+      // Attempt to archive the animal first.
       // This update will only succeed if the animal is not already archived.
       const updateResult = await tx.animal.updateMany({
         where: {
@@ -88,7 +66,7 @@ const _createOutcome = async (
         },
         data: {
           listingStatus: AnimalListingStatus.ARCHIVED,
-          archiveReason: archiveReason,
+          archiveReason: outcomeType,
         },
       });
 
@@ -241,7 +219,6 @@ const _updateOutcome = async (
 
   const { outcomeDate, outcomeType, destinationPartnerId, notes } =
     validatedFields.data;
-  const archiveReason = getArchiveReasonFromOutcomeType(outcomeType);
 
   try {
     const existingOutcome = await prisma.outcome.findUnique({
@@ -270,7 +247,7 @@ const _updateOutcome = async (
       // Update the animal's archive reason in case the type changed
       await tx.animal.update({
         where: { id: existingOutcome.animalId },
-        data: { archiveReason: archiveReason },
+        data: { archiveReason: outcomeType },
       });
     });
 

--- a/app/lib/actions/person.actions.ts
+++ b/app/lib/actions/person.actions.ts
@@ -29,7 +29,7 @@ const _createPerson = async (
     };
   }
 
-  const { name, type, email, phone, address, city, state, zipCode } =
+  const { name, email, phone, address, city, state, zipCode } =
     validatedFields.data;
 
   let newPersonId: string;
@@ -38,7 +38,6 @@ const _createPerson = async (
     const person = await prisma.person.create({
       data: {
         name,
-        type,
         email: email || null,
         phone: phone || null,
         address: address || null,
@@ -90,7 +89,7 @@ const _updatePerson = async (
     };
   }
 
-  const { name, type, email, phone, address, city, state, zipCode } =
+  const { name, email, phone, address, city, state, zipCode } =
     validatedFields.data;
 
   try {
@@ -98,7 +97,6 @@ const _updatePerson = async (
       where: { id: parsedId.data },
       data: {
         name,
-        type,
         email: email || null,
         phone: phone || null,
         address: address || null,
@@ -157,22 +155,10 @@ const _updateMyProfile = async (
     validatedFields.data;
 
   try {
-    // Look up the existing `type` so self-service edits can never change it,
-    // regardless of what the (hidden/unused) field in the submitted form contains.
-    const existingPerson = await prisma.person.findUnique({
-      where: { id: personId },
-      select: { type: true },
-    });
-
-    if (!existingPerson) {
-      return { message: "Profile not found." };
-    }
-
     await prisma.person.update({
       where: { id: personId },
       data: {
         name,
-        type: existingPerson.type, // preserved, not user-editable
         email: email || null,
         phone: phone || null,
         address: address || null,
@@ -182,14 +168,16 @@ const _updateMyProfile = async (
       },
     });
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
-    ) {
-      return {
-        errors: { email: ["A person with this email already exists."] },
-        message: "Failed to update profile.",
-      };
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        return {
+          errors: { email: ["A person with this email already exists."] },
+          message: "Failed to update profile.",
+        };
+      }
+      if (error.code === "P2025") {
+        return { message: "Profile not found." };
+      }
     }
     console.error("Database Error updating profile:", error);
     return {

--- a/app/lib/auth/ownership.ts
+++ b/app/lib/auth/ownership.ts
@@ -4,9 +4,9 @@
  * @param userPersonId - The ID of the currently authenticated user.
  * @returns True if the resource is not null and the resource.userId matches userPersonId.
  */
-export function isOwnedByUser<T extends { userId: string }>(
+export function isOwnedByUser<T extends { applicantId: string }>(
   resource: T | null,
   userPersonId: string
 ): resource is T {
-  return resource !== null && resource.userId === userPersonId;
+  return resource !== null && resource.applicantId === userPersonId;
 }

--- a/app/lib/data/animals/outcome.data.ts
+++ b/app/lib/data/animals/outcome.data.ts
@@ -61,7 +61,7 @@ export const _fetchOutcomeById = async (outcomeId: string) => {
                 },
                 adoptionApplications: {
                   select: {
-                    userId: true,
+                    applicantId: true,
                   },
                 },
               },

--- a/app/lib/data/my-applications.data.ts
+++ b/app/lib/data/my-applications.data.ts
@@ -56,7 +56,7 @@ const _fetchMyApplications = async (
   })();
 
   const whereClause: Prisma.AdoptionApplicationWhereInput = {
-    userId: personId,
+    applicantId: personId,
     animal: {
       name: {
         contains: query,
@@ -133,7 +133,7 @@ const _fetchMyAppById = async (
     const myApplication = await prisma.adoptionApplication.findFirst({
       where: {
         id: validatedAdoptionAppId,
-        userId: personId,
+        applicantId: personId,
       },
       include: {
         animal: {
@@ -152,7 +152,7 @@ const _fetchMyAppById = async (
             },
             adoptionApplications: {
               select: {
-                userId: true,
+                applicantId: true,
               },
             },
           },
@@ -203,10 +203,10 @@ const _getAnimalForApplication = async (
         },
         adoptionApplications: {
           where: {
-            userId: personId,
+            applicantId: personId,
           },
           select: {
-            userId: true,
+            applicantId: true,
           },
         },
       },

--- a/app/lib/data/people-directory/people-directory.data.ts
+++ b/app/lib/data/people-directory/people-directory.data.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/app/lib/prisma";
-import { PersonType, Prisma, Role } from "@prisma/client";
+import { Prisma, Role } from "@prisma/client";
 import {
   RequirePermission,
   SessionUser,
@@ -20,7 +20,7 @@ const _fetchPeople = async (
   currentPageInput: number,
   sortInput: string | undefined,
   pageSizeInput: number,
-  typeInput: string | undefined,
+  accountInput: string | undefined,
 ): Promise<{
   people: PeopleDirectoryPayload[];
   totalPages: number;
@@ -31,13 +31,13 @@ const _fetchPeople = async (
     currentPage: currentPageInput,
     sort: sortInput,
     pageSize: pageSizeInput,
-    type: typeInput,
+    account: accountInput,
   });
 
   if (!validatedArgs.success) {
     throw new Error("Invalid arguments for fetching people.");
   }
-  const { query, currentPage, sort, pageSize, type } = validatedArgs.data;
+  const { query, currentPage, sort, pageSize, account } = validatedArgs.data;
 
   const offset = (currentPage - 1) * pageSize;
 
@@ -81,13 +81,26 @@ const _fetchPeople = async (
     ],
   };
 
-  // If specific types are selected (and it's not "all of them"), apply the filter
-  const allPersonTypes = Object.values(PersonType);
-  if (type && type.length > 0 && type.length < allPersonTypes.length) {
-    whereClause.AND = [
-      ...(whereClause.AND as Prisma.PersonWhereInput[]),
-      { type: { in: type } },
-    ];
+  // REPLACE with account filtering.
+  // The faceted filter sends a comma-separated string; only filter when
+  // exactly one option is selected (both selected = no filter needed).
+  if (account) {
+    const selected = account.split(",").filter(Boolean);
+    const wantsRegistered = selected.includes("registered");
+    const wantsNoAccount = selected.includes("no_account");
+
+    // Only narrow when exactly one of the two is chosen
+    if (wantsRegistered && !wantsNoAccount) {
+      whereClause.AND = [
+        ...(whereClause.AND as Prisma.PersonWhereInput[]),
+        { user: { isNot: null } },
+      ];
+    } else if (wantsNoAccount && !wantsRegistered) {
+      whereClause.AND = [
+        ...(whereClause.AND as Prisma.PersonWhereInput[]),
+        { user: { is: null } },
+      ];
+    }
   }
 
   try {
@@ -101,7 +114,6 @@ const _fetchPeople = async (
         select: {
           id: true,
           name: true,
-          type: true,
           email: true,
           phone: true,
           city: true,
@@ -141,7 +153,6 @@ const _fetchSectionCardsPersonData = async (
       select: {
         id: true,
         name: true,
-        type: true,
         email: true,
         phone: true,
         address: true,
@@ -199,7 +210,6 @@ const _fetchPersonForEdit = async (
       select: {
         id: true,
         name: true,
-        type: true,
         email: true,
         phone: true,
         address: true,
@@ -233,7 +243,6 @@ const _fetchMyProfile = async (
       select: {
         id: true,
         name: true,
-        type: true,
         email: true,
         phone: true,
         address: true,

--- a/app/lib/data/people-directory/person-adoption-applications.data.ts
+++ b/app/lib/data/people-directory/person-adoption-applications.data.ts
@@ -59,7 +59,7 @@ const _fetchPersonAdoptionApplications = async (
   const { currentPage, personId } = validatedArgs.data;
 
   const whereClause: Prisma.AdoptionApplicationWhereInput = {
-    userId: personId,
+    applicantId: personId,
   };
 
   try {

--- a/app/lib/data/public.data.ts
+++ b/app/lib/data/public.data.ts
@@ -193,11 +193,11 @@ export const fetchPublicPagePetById = async (id: string) => {
         ...(personId && {
           adoptionApplications: {
             where: {
-              userId: personId,
+              applicantId: personId,
             },
             select: {
               id: true,
-              userId: true,
+              applicantId: true,
               status: true,
             },
             take: 1,

--- a/app/lib/data/user-application.data.ts
+++ b/app/lib/data/user-application.data.ts
@@ -52,7 +52,7 @@ export type ApplicationWithOutcome = Prisma.AdoptionApplicationGetPayload<{
         };
         adoptionApplications: {
           select: {
-            userId: true;
+            applicantId: true;
           };
         };
       };
@@ -221,7 +221,7 @@ const _fetchUserApplicationById = async (
             },
             adoptionApplications: {
               select: {
-                userId: true,
+                applicantId: true,
               },
             },
           },

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -149,7 +149,7 @@ export type AdoptionApplicationPayload = Prisma.AdoptionApplicationGetPayload<{
         };
         adoptionApplications: {
           select: {
-            userId: true;
+            applicantId: true;
           };
         };
       };
@@ -172,7 +172,7 @@ export type AnimalForApplicationPayload = Prisma.AnimalGetPayload<{
       select: { name: true };
     };
     adoptionApplications: {
-      select: { userId: true };
+      select: { applicantId: true };
     };
   };
 }>;
@@ -305,7 +305,6 @@ export type PeopleDirectoryPayload = Prisma.PersonGetPayload<{
   select: {
     id: true;
     name: true;
-    type: true;
     email: true;
     phone: true;
     city: true;
@@ -322,7 +321,6 @@ export type PersonSectionCardPayload = Prisma.PersonGetPayload<{
   select: {
     id: true;
     name: true;
-    type: true;
     email: true;
     phone: true;
     address: true;
@@ -358,7 +356,6 @@ export type PersonFormPayload = Prisma.PersonGetPayload<{
   select: {
     id: true;
     name: true;
-    type: true;
     email: true;
     phone: true;
     address: true;

--- a/app/lib/zod-schemas/people-directory.schemas.ts
+++ b/app/lib/zod-schemas/people-directory.schemas.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { PersonType } from "@prisma/client";
 import {
   currentPageSchema,
   pageSizeSchema,
@@ -12,11 +11,7 @@ export const PeopleDirectoryParamsSchema = z.object({
   currentPage: currentPageSchema,
   sort: z.string().optional(),
   pageSize: pageSizeSchema,
-  type: z
-    .string()
-    .optional()
-    .transform((val) => val?.split(",").filter(Boolean))
-    .pipe(z.array(z.enum(PersonType)).optional()),
+  account: z.string().optional(),
 });
 
 const stateCodes = US_STATES.map((state) => state.code) as [
@@ -27,10 +22,6 @@ const stateCodes = US_STATES.map((state) => state.code) as [
 export const PersonFormSchema = z.object({
   name: z.string().min(1, {
     error: "Name is required.",
-  }),
-  type: z.enum(PersonType, {
-    error: (issue) =>
-      issue.input === undefined ? "Type is required." : undefined,
   }),
   email: z
     .email({ error: "Please enter a valid email address." })

--- a/components/dashboard/people-directory/person-form.tsx
+++ b/components/dashboard/people-directory/person-form.tsx
@@ -40,7 +40,6 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { PersonType } from "@prisma/client";
 import { PersonFormSchema } from "@/app/lib/zod-schemas/people-directory.schemas";
 import { US_STATES } from "@/app/lib/constants/us-states";
 import Link from "next/link";
@@ -62,7 +61,6 @@ const PersonForm = ({
   returnTo,
 }: PersonFormProps) => {
   const isEditMode = !!person;
-  const showTypeField = mode === "staff";
 
   const resolvedCancelHref =
     cancelHref ??
@@ -87,7 +85,6 @@ const PersonForm = ({
     defaultValues: isEditMode
       ? {
           name: person.name,
-          type: person.type,
           email: person.email || "",
           phone: person.phone || "",
           address: person.address || "",
@@ -97,7 +94,6 @@ const PersonForm = ({
         }
       : {
           name: "",
-          type: PersonType.INDIVIDUAL,
           email: "",
           phone: "",
           address: "",
@@ -154,7 +150,7 @@ const PersonForm = ({
                 ? "Update your contact information."
                 : isEditMode
                   ? `Editing the record for ${person.name}.`
-                  : "Register a new contact record — e.g., a walk-in contact or partner agency."}
+                  : "Register a new contact record — e.g., a walk-in contact or partner."}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-10">
@@ -180,36 +176,6 @@ const PersonForm = ({
                     </FormItem>
                   )}
                 />
-                {showTypeField && (
-                  <FormField
-                    control={form.control}
-                    name="type"
-                    render={({ field }) => (
-                      <FormItem className="col-span-2">
-                        <FormLabel>Type</FormLabel>
-                        <Select
-                          onValueChange={field.onChange}
-                          value={field.value}
-                        >
-                          <FormControl>
-                            <SelectTrigger className="w-full">
-                              <SelectValue placeholder="Select type" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            <SelectItem value={PersonType.INDIVIDUAL}>
-                              Individual
-                            </SelectItem>
-                            <SelectItem value={PersonType.AGENCY}>
-                              Agency
-                            </SelectItem>
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                )}
                 <FormField
                   control={form.control}
                   name="email"

--- a/components/dashboard/people-directory/person-section-cards.tsx
+++ b/components/dashboard/people-directory/person-section-cards.tsx
@@ -12,15 +12,12 @@ import { PersonSectionCardPayload, IDParamType } from "@/app/lib/types";
 import { fetchSectionCardsPersonData } from "@/app/lib/data/people-directory/people-directory.data";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { PersonType } from "@prisma/client";
 import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
 import {
   Mail,
   Phone,
   MapPin,
-  Building2,
   User as UserIcon,
-  PawPrint,
   ClipboardList,
   LogIn,
 } from "lucide-react";
@@ -63,12 +60,8 @@ const PersonSectionCards = async ({ params }: Props) => {
             <div className="flex-1">
               <CardTitle className="mb-1">{person.name}</CardTitle>
               <CardDescription className="flex items-center gap-1">
-                {person.type === PersonType.AGENCY ? (
-                  <Building2 className="h-3 w-3" />
-                ) : (
-                  <UserIcon className="h-3 w-3" />
-                )}
-                {formatSingleEnumOption(person.type)}
+                <UserIcon className="h-3 w-3" />
+                {person.user ? "Registered User" : "Contact Record"}
               </CardDescription>
               {fullAddress && (
                 <div className="flex items-center gap-1 text-sm text-muted-foreground mt-2">
@@ -100,9 +93,7 @@ const PersonSectionCards = async ({ params }: Props) => {
                   className="object-cover"
                 />
               ) : (
-                <span className="text-4xl">
-                  {person.type === PersonType.AGENCY ? "🏢" : "👤"}
-                </span>
+                <span className="text-4xl">👤</span>
               )}
             </div>
 

--- a/components/dashboard/people-directory/table/people-directory-options.tsx
+++ b/components/dashboard/people-directory/table/people-directory-options.tsx
@@ -1,19 +1,18 @@
-import { PersonType } from "@prisma/client";
-import { User, Building2 } from "lucide-react";
+import { UserCheck, UserX } from "lucide-react";
 
-export const PersonTypes = [
+export const AccountStatuses = [
   {
-    value: PersonType.INDIVIDUAL,
-    label: "Individual",
-    icon: User,
+    value: "registered",
+    label: "Registered",
+    icon: UserCheck,
     className:
-      "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-800",
+      "bg-green-50 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-300 dark:border-green-800",
   },
   {
-    value: PersonType.AGENCY,
-    label: "Agency",
-    icon: Building2,
+    value: "no_account",
+    label: "No Account",
+    icon: UserX,
     className:
-      "bg-orange-50 text-orange-700 border-orange-200 dark:bg-orange-950 dark:text-orange-300 dark:border-orange-800",
+      "bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700",
   },
 ];

--- a/components/dashboard/people-directory/table/people-directory-table-columns.tsx
+++ b/components/dashboard/people-directory/table/people-directory-table-columns.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { DataTableColumnHeader } from "../../../table-common/data-table-column-header";
 import { DataTableRowActions } from "./people-directory-table-row-actions";
 import { PeopleDirectoryPayload } from "@/app/lib/types";
-import { PersonTypes } from "./people-directory-options";
+import { AccountStatuses } from "./people-directory-options";
 
 export const columns: ColumnDef<PeopleDirectoryPayload>[] = [
   {
@@ -51,39 +51,27 @@ export const columns: ColumnDef<PeopleDirectoryPayload>[] = [
     },
   },
   {
-    accessorKey: "type",
+    id: "account",
+    accessorFn: (row) => (row.user ? "registered" : "no_account"),
     header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Type" />
+      <DataTableColumnHeader column={column} title="Account" />
     ),
     cell: ({ row }) => {
-      const type = PersonTypes.find((t) => t.value === row.original.type);
-      if (!type)
-        return (
-          <span className="capitalize">{row.original.type.toLowerCase()}</span>
-        );
+      const status = AccountStatuses.find(
+        (s) => s.value === row.getValue("account"),
+      );
+      if (!status) return null;
 
+      const Icon = status.icon;
       return (
-        <Badge variant="outline" className={type.className}>
-          {type.label}
+        <Badge variant="outline" className={status.className}>
+          <Icon className="mr-1 h-3 w-3" />
+          {status.label}
         </Badge>
       );
     },
     filterFn: (row, id, value) => {
       return value.includes(row.getValue(id));
-    },
-  },
-  {
-    id: "account",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Account" />
-    ),
-    cell: ({ row }) => {
-      const hasAccount = !!row.original.user;
-      return (
-        <Badge variant={hasAccount ? "outline" : "secondary"}>
-          {hasAccount ? "Registered" : "No Account"}
-        </Badge>
-      );
     },
     enableSorting: false,
   },

--- a/components/dashboard/people-directory/table/people-directory-table-toolbar.tsx
+++ b/components/dashboard/people-directory/table/people-directory-table-toolbar.tsx
@@ -4,7 +4,7 @@ import { Table } from "@tanstack/react-table";
 import { PeopleDirectoryPayload } from "@/app/lib/types";
 import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
 import { DataTableToolbar } from "@/components/table-common/data-table-toolbar";
-import { PersonTypes } from "./people-directory-options";
+import { AccountStatuses } from "./people-directory-options";
 
 interface PeopleTableToolbarProps {
   table: Table<PeopleDirectoryPayload>;
@@ -16,12 +16,12 @@ const PeopleTableToolbar = ({ table }: PeopleTableToolbarProps) => {
       table={table}
       searchId="people-search"
       searchPlaceholder="Filter by name, email, or phone..."
-      filterParamKeys={["type"]}
+      filterParamKeys={["account"]}
       filters={
         <ServerSideFacetedFilter
-          title="Type"
-          paramKey="type"
-          options={PersonTypes}
+          title="Account"
+          paramKey="account"
+          options={AccountStatuses}
         />
       }
     />

--- a/prisma/migrations/20260616052150_schema_cleanup/migration.sql
+++ b/prisma/migrations/20260616052150_schema_cleanup/migration.sql
@@ -1,0 +1,37 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `user_id` on the `adoption_applications` table. All the data in the column will be lost.
+  - The `archiveReason` column on the `animals` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - You are about to drop the column `type` on the `persons` table. All the data in the column will be lost.
+  - Added the required column `applicant_id` to the `adoption_applications` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "adoption_applications" DROP CONSTRAINT "adoption_applications_user_id_fkey";
+
+-- DropIndex
+DROP INDEX "adoption_applications_user_id_idx";
+
+-- AlterTable
+ALTER TABLE "adoption_applications" DROP COLUMN "user_id",
+ADD COLUMN     "applicant_id" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "animals" DROP COLUMN "archiveReason",
+ADD COLUMN     "archiveReason" "OutcomeType";
+
+-- AlterTable
+ALTER TABLE "persons" DROP COLUMN "type";
+
+-- DropEnum
+DROP TYPE "AnimalArchiveReason";
+
+-- DropEnum
+DROP TYPE "PersonType";
+
+-- CreateIndex
+CREATE INDEX "adoption_applications_applicant_id_idx" ON "adoption_applications"("applicant_id");
+
+-- AddForeignKey
+ALTER TABLE "adoption_applications" ADD CONSTRAINT "adoption_applications_applicant_id_fkey" FOREIGN KEY ("applicant_id") REFERENCES "persons"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260616052150_schema_cleanup/migration.sql
+++ b/prisma/migrations/20260616052150_schema_cleanup/migration.sql
@@ -1,12 +1,3 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `user_id` on the `adoption_applications` table. All the data in the column will be lost.
-  - The `archiveReason` column on the `animals` table would be dropped and recreated. This will lead to data loss if there is data in the column.
-  - You are about to drop the column `type` on the `persons` table. All the data in the column will be lost.
-  - Added the required column `applicant_id` to the `adoption_applications` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- DropForeignKey
 ALTER TABLE "adoption_applications" DROP CONSTRAINT "adoption_applications_user_id_fkey";
 
@@ -14,8 +5,7 @@ ALTER TABLE "adoption_applications" DROP CONSTRAINT "adoption_applications_user_
 DROP INDEX "adoption_applications_user_id_idx";
 
 -- AlterTable
-ALTER TABLE "adoption_applications" DROP COLUMN "user_id",
-ADD COLUMN     "applicant_id" TEXT NOT NULL;
+ALTER TABLE "adoption_applications" RENAME COLUMN "user_id" TO "applicant_id";
 
 -- AlterTable
 ALTER TABLE "animals" DROP COLUMN "archiveReason",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,11 +30,6 @@ enum MedicalRecordType {
   NOTE // A general health-related note
 }
 
-enum PersonType {
-  INDIVIDUAL
-  AGENCY // For shelters, rescues, vet clinics, etc.
-}
-
 enum OutcomeType {
   ADOPTION
   TRANSFER_OUT
@@ -152,16 +147,6 @@ enum ApplicationStatus {
   REJECTED // Application rejected
   WITHDRAWN // Application withdrawn by the user
   ADOPTED // animal has been adopted through this application (final state)
-}
-
-enum AnimalArchiveReason {
-  ADOPTED_INTERNAL // Adopted through an application on this platform
-  ADOPTED_EXTERNAL // Adopted through an external process (e.g., in-person event)
-  TRANSFERRED // Moved to another rescue or shelter
-  RETURNED_TO_OWNER
-  DECEASED
-  EUTHANIZED
-  OTHER
 }
 
 enum LivingSituation {
@@ -294,7 +279,7 @@ model Animal {
   description     String?
   listingStatus   AnimalListingStatus  @default(DRAFT)
   microchipNumber String?              @unique
-  archiveReason   AnimalArchiveReason? /// Should only be set when listingStatus is ARCHIVED. Explains why the animal is no longer available.
+  archiveReason   OutcomeType? /// Should only be set when listingStatus is ARCHIVED. Explains why the animal is no longer available.
 
   // Relations
   // mandatory relationship to Species
@@ -524,22 +509,21 @@ model AdoptionApplication {
   internalNotes String? // For persistent staff notes about the application as a whole
 
   outcome Outcome?
-
   history ApplicationStatusHistory[]
 
   // Relations
-  userId   String @map(name: "user_id")
-  user     Person @relation(fields: [userId], references: [id], onDelete: Restrict) // Prevent deleting a user with applications
-  animalId String @map(name: "animal_id")
-  animal   Animal @relation(fields: [animalId], references: [id], onDelete: Cascade)
+  applicantId String @map(name: "applicant_id")
+  applicant   Person @relation(fields: [applicantId], references: [id], onDelete: Restrict) // Prevent deleting a user with applications
+  animalId    String @map(name: "animal_id")
+  animal      Animal @relation(fields: [animalId], references: [id], onDelete: Cascade)
 
   submittedAt DateTime @default(now()) @map(name: "submitted_at")
   updatedAt   DateTime @updatedAt @map(name: "updated_at")
 
   @@index([animalId])
-  @@index([userId])
+  @@index([applicantId])
   @@index([status])
-  @@index([animalId, status]) // For quickly finding applications for an animal in a certain status
+  @@index([animalId, status])
   @@map(name: "adoption_applications")
 }
 
@@ -594,7 +578,6 @@ model Person {
   // AGENCY type persons (e.g., external shelters, rescues) are contact/tracking records only.
   // They do not have a User account and cannot log in. They exist to link animals to
   // an organization via Intake, Outcome.
-  type    PersonType @default(INDIVIDUAL)
   email   String?    @unique
   phone   String?
   address String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -575,9 +575,6 @@ model AnimalImage {
 model Person {
   id      String     @id @default(cuid())
   name    String
-  // AGENCY type persons (e.g., external shelters, rescues) are contact/tracking records only.
-  // They do not have a User account and cannot log in. They exist to link animals to
-  // an organization via Intake, Outcome.
   email   String?    @unique
   phone   String?
   address String?

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,7 +3,6 @@ import {
   PrismaClient,
   Role,
   Sex,
-  PersonType,
   PartnerType,
   AnimalListingStatus,
   IntakeType,
@@ -45,42 +44,35 @@ const baseUrl = isDemo
 const personData = [
   {
     name: "External Agency",
-    type: PersonType.AGENCY,
     email: "agency@example.com",
   },
   {
     name: "Admin User",
-    type: PersonType.INDIVIDUAL,
     email: "admin@example.com",
     role: Role.ADMIN,
   },
   {
     name: "Olivia Chen",
-    type: PersonType.INDIVIDUAL,
     email: "staff1@example.com",
     role: Role.STAFF,
   },
   {
     name: "Benjamin Carter",
-    type: PersonType.INDIVIDUAL,
     email: "staff2@example.com",
     role: Role.STAFF,
   },
   {
     name: "Sam Rivera",
-    type: PersonType.INDIVIDUAL,
     email: "volunteer1@example.com",
     role: Role.VOLUNTEER,
   },
   {
     name: "Jane Doe",
-    type: PersonType.INDIVIDUAL,
     email: "surrenderer1@example.com",
     role: Role.USER,
   },
   {
     name: "John Smith",
-    type: PersonType.INDIVIDUAL,
     email: "finder1@example.com",
     role: Role.USER,
   },
@@ -575,7 +567,6 @@ async function seedPersonsAndUsers() {
     const person = await prisma.person.create({
       data: {
         name: pData.name,
-        type: pData.type,
         email: pData.email,
       },
     });


### PR DESCRIPTION
## Summary

Removes three schema redundancies surfaced during a review of the Prisma schema.

### 1. `AnimalArchiveReason` → `OutcomeType`
`AnimalArchiveReason` duplicated almost all of `OutcomeType`, requiring a translation helper (`getArchiveReasonFromOutcomeType`) to map between the two whenever an outcome was processed. The two enums could drift out of sync. `Animal.archiveReason` now uses `OutcomeType` directly and the helper is removed.
(The unused `ADOPTED_INTERNAL` / `ADOPTED_EXTERNAL` distinction was dropped, in-person adoptions go through the standard application flow, so they're just `ADOPTION`.)

### 2. `PersonType` removed in favor of `Partner`
`PersonType.AGENCY` overlapped conceptually with the `Partner` model (shelters, rescues, vet clinics, government agencies). `Partner` is already wired into `Intake.sourcePartner` and `Outcome.destinationPartner` and has organization appropriate fields. `PersonType` had no unique relations and only appeared in seed data. Removed the enum and the `Person.type` column; the People Directory type filter is replaced with an account-status filter (registered vs. no account).

### 3. `AdoptionApplication.userId` → `applicantId`
The field referenced `Person`, not `User`, despite its name, misleading now that staff can create applications on behalf of walk-in contacts without accounts. Renamed for accuracy.

## Migration notes
- The migration uses `RENAME COLUMN` for `user_id` → `applicant_id` (not drop/add) so it applies cleanly whether the table is empty or populated.
- Verified with `prisma migrate reset` locally.
- `HouseholdProfile` / `AdoptionApplication` field duplication was reviewed and intentionally kept, the application stores a point-in-time snapshot.