### PR TITLE
Partner & Person Notes + consistent note status filtering

### DIFF
--- a/app/api/reset-demo/route.ts
+++ b/app/api/reset-demo/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
     await prisma.animalActivityLog.deleteMany({});
     await prisma.templateField.deleteMany({});
     await prisma.medicalRecord.deleteMany({});
-    await prisma.note.deleteMany({});
+    await prisma.animalNote.deleteMany({});
     await prisma.task.deleteMany({});
     await prisma.assessment.deleteMany({});
     

--- a/app/dashboard/animals/[id]/(with-layout)/notes/page.tsx
+++ b/app/dashboard/animals/[id]/(with-layout)/notes/page.tsx
@@ -28,18 +28,17 @@ const PageContent = async ({ params, searchParams }: Props) => {
   const {
     page = "1",
     category,
-    sort, // e.g., "Newest first", "Oldest first"
-    showDeleted,
+    sort,
+    status,
   } = await searchParams;
   const currentPage = Number(page);
-  const includeDeleted = showDeleted === "true";
 
   const { notes, totalPages } = await fetchAnimalNotes(
     currentPage,
     category,
     sort,
     animalId,
-    includeDeleted,
+    status,
   );
 
   return (

--- a/app/dashboard/partners-directory/[id]/(with-layout)/(animal-history)/page.tsx
+++ b/app/dashboard/partners-directory/[id]/(with-layout)/(animal-history)/page.tsx
@@ -1,0 +1,31 @@
+import { IDParamType } from "@/app/lib/types";
+import { fetchPartnerAnimalHistory } from "@/app/lib/data/partners-directory/partner-animal-history.data";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import PartnerAnimalHistory from "@/components/dashboard/partners-directory/animal-history/partner-animal-history";
+
+interface Props {
+  params: IDParamType;
+}
+
+const Page = async ({ params }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent params={params} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ params }: Props) => {
+  const { id: partnerId } = await params;
+
+  const { history } = await fetchPartnerAnimalHistory(partnerId);
+
+  return <PartnerAnimalHistory history={history} />;
+};
+
+export default Page;

--- a/app/dashboard/partners-directory/[id]/(with-layout)/contacts/page.tsx
+++ b/app/dashboard/partners-directory/[id]/(with-layout)/contacts/page.tsx
@@ -1,0 +1,49 @@
+import { IDParamType } from "@/app/lib/types";
+import {
+  fetchPartnerContacts,
+  fetchLinkablePeople,
+} from "@/app/lib/data/partners-directory/partner-contacts.data";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { hasPermission } from "@/app/lib/auth/hasPermission";
+import PartnerContacts from "@/components/dashboard/partners-directory/contacts/partner-contacts";
+
+interface Props {
+  params: IDParamType;
+}
+
+const Page = async ({ params }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent params={params} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ params }: Props) => {
+  const { id: partnerId } = await params;
+
+  const canManage = await hasPermission(AppPermissions.PARTNERS_MANAGE);
+
+  const { contacts } = await fetchPartnerContacts(partnerId);
+
+  // Only managers can add contacts, so only fetch the linkable list for them.
+  const { people } = canManage
+    ? await fetchLinkablePeople(partnerId)
+    : { people: [] };
+
+  return (
+    <PartnerContacts
+      contacts={contacts}
+      people={people}
+      partnerId={partnerId}
+      canManage={canManage}
+    />
+  );
+};
+
+export default Page;

--- a/app/dashboard/partners-directory/[id]/(with-layout)/layout.tsx
+++ b/app/dashboard/partners-directory/[id]/(with-layout)/layout.tsx
@@ -1,0 +1,26 @@
+import { IDParamType } from "@/app/lib/types";
+import { PartnerNavTabs } from "@/components/dashboard/partners-directory/tabs-nav/partner-nav-tabs";
+import { Suspense } from "react";
+import PartnerSectionCards from "@/components/dashboard/partners-directory/partner-section-cards";
+import PartnerSectionCardsSkeleton from "@/components/skeletons/partnerSectionCardsSkeleton";
+
+interface Props {
+  children: React.ReactNode;
+  params: IDParamType;
+}
+
+const Layout = ({ children, params }: Props) => {
+  return (
+    <>
+      <Suspense fallback={<PartnerSectionCardsSkeleton />}>
+        <PartnerSectionCards params={params} />
+      </Suspense>
+
+      <PartnerNavTabs />
+
+      {children}
+    </>
+  );
+};
+
+export default Layout;

--- a/app/dashboard/partners-directory/[id]/(with-layout)/notes/page.tsx
+++ b/app/dashboard/partners-directory/[id]/(with-layout)/notes/page.tsx
@@ -1,0 +1,50 @@
+import { IDParamType, SearchParamsType } from "@/app/lib/types";
+import { fetchPartnerNotes } from "@/app/lib/data/partners-directory/partner-notes.data";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { hasPermission } from "@/app/lib/auth/hasPermission";
+import PartnerNotes from "@/components/dashboard/partners-directory/notes/partner-notes";
+
+interface Props {
+  params: IDParamType;
+  searchParams: SearchParamsType;
+}
+
+const Page = async ({ params, searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent params={params} searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ params, searchParams }: Props) => {
+  const { id: partnerId } = await params;
+  const { page = "1", sort, status } = await searchParams;
+  const currentPage = Number(page);
+
+  const { notes, totalPages, totalRows } = await fetchPartnerNotes(
+    partnerId,
+    currentPage,
+    sort,
+    status,
+  );
+
+  const canManage = await hasPermission(AppPermissions.PARTNERS_MANAGE);
+
+  return (
+    <PartnerNotes
+      notes={notes}
+      totalPages={totalPages}
+      totalRows={totalRows}
+      partnerId={partnerId}
+      canManage={canManage}
+    />
+  );
+};
+
+export default Page;

--- a/app/dashboard/partners-directory/[id]/edit/page.tsx
+++ b/app/dashboard/partners-directory/[id]/edit/page.tsx
@@ -1,0 +1,43 @@
+import PartnerForm from "@/components/dashboard/partners-directory/partner-form";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { fetchPartnerForEdit } from "@/app/lib/data/partners-directory/partners-directory.data";
+import { IDParamType, SearchParamsType } from "@/app/lib/types";
+import { notFound } from "next/navigation";
+
+interface Props {
+  params: IDParamType;
+  searchParams: SearchParamsType;
+}
+
+const Page = async ({ params, searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_MANAGE}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent params={params} searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ params, searchParams }: Props) => {
+  const { id } = await params;
+  const { returnTo } = await searchParams;
+  const resolvedReturnTo = typeof returnTo === "string" ? returnTo : undefined;
+
+  const partner = await fetchPartnerForEdit(id);
+
+  if (!partner) {
+    notFound();
+  }
+
+  return (
+    <main>
+      <PartnerForm partner={partner} returnTo={resolvedReturnTo} />
+    </main>
+  );
+};
+
+export default Page;

--- a/app/dashboard/partners-directory/new/page.tsx
+++ b/app/dashboard/partners-directory/new/page.tsx
@@ -1,0 +1,19 @@
+import PartnerForm from "@/components/dashboard/partners-directory/partner-form";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+
+const Page = async () => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_MANAGE}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <main>
+        <PartnerForm />
+      </main>
+    </Authorize>
+  );
+};
+
+export default Page;

--- a/app/dashboard/partners-directory/page.tsx
+++ b/app/dashboard/partners-directory/page.tsx
@@ -1,0 +1,111 @@
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { SearchParamsType } from "@/app/lib/types";
+import PartnersTableToolbar from "@/components/dashboard/partners-directory/table/partners-directory-table-toolbar";
+import { getColumns } from "@/components/dashboard/partners-directory/table/partners-directory-table-columns";
+import DataTable from "@/components/table-common/data-table";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { fetchPartners } from "@/app/lib/data/partners-directory/partners-directory.data";
+import { hasPermission } from "@/app/lib/auth/hasPermission";
+
+interface Props {
+  searchParams: SearchParamsType;
+}
+
+const Page = async ({ searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PARTNERS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ searchParams }: Props) => {
+  const {
+    query = "",
+    page = "1",
+    pageSize = "10",
+    sort,
+    type,
+    status,
+  } = await searchParams;
+  const currentPage = Number(page);
+  const currentPageSize = Number(pageSize);
+
+  const { partners, totalPages, totalRows } = await fetchPartners(
+    query,
+    currentPage,
+    sort,
+    currentPageSize,
+    type,
+    status,
+  );
+
+  const canManage = await hasPermission(AppPermissions.PARTNERS_MANAGE);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle className="font-semibold tabular-nums @[650px]/card:text-xl">
+          Partner Directory
+        </CardTitle>
+        <CardDescription>
+          View and manage shelters, rescue groups, vet clinics, and government
+          agencies.
+        </CardDescription>
+        <CardAction>
+          <span
+            className={cn("inline-block", !canManage && "cursor-not-allowed")}
+          >
+            <Button
+              asChild
+              size="sm"
+              variant={canManage ? "default" : "outline"}
+              className={cn(!canManage && "pointer-events-none opacity-50")}
+            >
+              <Link
+                href="/dashboard/partners-directory/new"
+                aria-disabled={!canManage}
+                tabIndex={canManage ? undefined : -1}
+              >
+                Add Partner
+              </Link>
+            </Button>
+          </span>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-1 flex-col">
+          <div className="@container/main flex flex-1 flex-col gap-2">
+            <div className="flex flex-col gap-4 md:gap-6">
+              <DataTable
+                data={partners}
+                getColumns={getColumns}
+                columnProps={{ canManage }}
+                ToolbarComponent={PartnersTableToolbar}
+                totalPages={totalPages}
+                totalRows={totalRows}
+              />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default Page;

--- a/app/dashboard/people-directory/[id]/(with-layout)/adoption-applications/page.tsx
+++ b/app/dashboard/people-directory/[id]/(with-layout)/adoption-applications/page.tsx
@@ -40,7 +40,7 @@ const PageContent = async ({ searchParams, params }: Props) => {
   return (
     <Card className="@container/card">
       <CardHeader>
-        <CardTitle className="font-semibold tabular-nums @[650px]/card:text-xl">
+        <CardTitle>
           Adoption Applications
         </CardTitle>
         <CardDescription>

--- a/app/dashboard/people-directory/[id]/(with-layout)/notes/page.tsx
+++ b/app/dashboard/people-directory/[id]/(with-layout)/notes/page.tsx
@@ -1,0 +1,49 @@
+import { IDParamType, SearchParamsType } from "@/app/lib/types";
+import { fetchPersonNotes } from "@/app/lib/data/people-directory/person-notes.data";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { hasPermission } from "@/app/lib/auth/hasPermission";
+import PersonNotes from "@/components/dashboard/people-directory/notes/person-notes";
+
+interface Props {
+  params: IDParamType;
+  searchParams: SearchParamsType;
+}
+
+const Page = async ({ params, searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.PERSONS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent params={params} searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ params, searchParams }: Props) => {
+  const { id: personId } = await params;
+  const { page = "1", sort, status } = await searchParams;
+  const currentPage = Number(page);
+
+  const { notes, totalPages } = await fetchPersonNotes(
+    personId,
+    currentPage,
+    sort,
+    status,
+  );
+
+  const canManage = await hasPermission(AppPermissions.PERSONS_MANAGE);
+
+  return (
+    <PersonNotes
+      notes={notes}
+      totalPages={totalPages}
+      personId={personId}
+      canManage={canManage}
+    />
+  );
+};
+
+export default Page;

--- a/app/lib/actions/adoption-application.actions.ts
+++ b/app/lib/actions/adoption-application.actions.ts
@@ -11,6 +11,7 @@ import { AppPermissions } from "@/app/lib/auth/permissions";
 import { ApplicationStatus, AnimalListingStatus, Prisma } from "@prisma/client";
 import { auth } from "@/auth";
 import { ConflictError } from "../utils/errors";
+import { z } from "zod";
 
 const _staffUpdateAdoptionApp = async (
   adoptionAppId: string,
@@ -60,7 +61,7 @@ const _staffUpdateAdoptionApp = async (
       validatedFields.error
     );
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message:
         "Missing or Invalid Fields. Failed to Update Adoption Application.",
     };

--- a/app/lib/actions/animal-note.actions.ts
+++ b/app/lib/actions/animal-note.actions.ts
@@ -48,7 +48,7 @@ const _createAnimalNote = async (
   const { category, content } = validatedFields.data;
 
   try {
-    await prisma.note.create({
+    await prisma.animalNote.create({
       data: {
         category: category,
         content: content,
@@ -110,7 +110,7 @@ const _updateAnimalNote = async (
   const { category, content } = validatedFields.data;
 
   try {
-    await prisma.note.update({
+    await prisma.animalNote.update({
       where: {
         id: parsedNoteId.data,
         animalId: parsedAnimalId.data,
@@ -148,7 +148,7 @@ const _deleteAnimalNote = async (
   }
 
   try {
-    await prisma.note.update({
+    await prisma.animalNote.update({
       where: {
         id: parsedNoteId.data,
       },
@@ -183,7 +183,7 @@ const _restoreAnimalNote = async (
   }
 
   try {
-    await prisma.note.update({
+    await prisma.animalNote.update({
       where: {
         id: parsedNoteId.data,
       },

--- a/app/lib/actions/animal-note.actions.ts
+++ b/app/lib/actions/animal-note.actions.ts
@@ -10,6 +10,7 @@ import {
 } from "../auth/protected-actions";
 import { AppPermissions } from "@/app/lib/auth/permissions";
 import { NoteFormSchema } from "../zod-schemas/animal.schemas";
+import { z } from "zod";
 
 export interface AnimalNoteFormState {
   success?: boolean;
@@ -40,7 +41,7 @@ const _createAnimalNote = async (
   if (!validatedFields.success) {
     return {
       success: false,
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to create animal.",
     };
   }
@@ -102,7 +103,7 @@ const _updateAnimalNote = async (
   if (!validatedFields.success) {
     return {
       success: false,
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to update note.",
     };
   }

--- a/app/lib/actions/animal-task.actions.ts
+++ b/app/lib/actions/animal-task.actions.ts
@@ -33,7 +33,7 @@ const _createAnimalTask = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to create task.",
     };
   }
@@ -96,7 +96,7 @@ const _updateAnimalTask = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to update task.",
     };
   }

--- a/app/lib/actions/household-profile.actions.ts
+++ b/app/lib/actions/household-profile.actions.ts
@@ -11,6 +11,7 @@ import {
 } from "../auth/protected-actions";
 import { AppPermissions } from "@/app/lib/auth/permissions";
 import { HouseholdProfileFormSchema } from "../zod-schemas/household-profile.schemas";
+import { z } from "zod";
 
 const _updateMyHouseholdProfile = async (
   user: SessionUser,
@@ -25,7 +26,7 @@ const _updateMyHouseholdProfile = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to update household profile.",
     };
   }

--- a/app/lib/actions/intake.actions.ts
+++ b/app/lib/actions/intake.actions.ts
@@ -16,6 +16,7 @@ import {
 } from "../auth/protected-actions";
 import { cuidSchema } from "../zod-schemas/common.schemas";
 import { ReIntakeFormSchema } from "../zod-schemas/intake.schema";
+import { z } from "zod";
 
 export type IntakeFormState = {
   message?: string | null;
@@ -77,7 +78,7 @@ const _createReIntake = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to process re-intake.",
     };
   }

--- a/app/lib/actions/outcome.actions.ts
+++ b/app/lib/actions/outcome.actions.ts
@@ -21,6 +21,7 @@ import {
   NotFoundError,
   PreconditionFailedError,
 } from "../utils/errors";
+import { z } from "zod";
 
 interface CreateOutcomeIds {
   animalId: string;
@@ -47,7 +48,7 @@ const _createOutcome = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or Invalid Fields. Failed to Process Outcome.",
     };
   }
@@ -212,7 +213,7 @@ const _updateOutcome = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or Invalid Fields. Failed to Update Outcome.",
     };
   }

--- a/app/lib/actions/partner-contact.actions.ts
+++ b/app/lib/actions/partner-contact.actions.ts
@@ -1,0 +1,300 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { PartnerContactFormSchema } from "../zod-schemas/partners-directory.schemas";
+import { z } from "zod";
+
+export type PartnerContactFormState = {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    personId?: string[];
+    role?: string[];
+    isPrimary?: string[];
+    isActive?: string[];
+  };
+};
+
+const revalidateContacts = (partnerId: string) => {
+  revalidatePath(`/dashboard/partners-directory/${partnerId}`);
+  revalidatePath(`/dashboard/partners-directory/${partnerId}/contacts`);
+};
+
+const _addPartnerContact = async (
+  partnerId: string,
+  prevState: PartnerContactFormState,
+  formData: FormData,
+): Promise<PartnerContactFormState> => {
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedPartnerId.success) {
+    return { message: "Invalid partner ID format." };
+  }
+
+  const raw = Object.fromEntries(formData.entries());
+  const validatedFields = PartnerContactFormSchema.safeParse({
+    ...raw,
+    isPrimary: formData.get("isPrimary") !== null,
+    isActive: formData.get("isActive") !== null,
+  });
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to add contact.",
+    };
+  }
+
+  const { personId, role, isPrimary, isActive } = validatedFields.data;
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      // If this contact will be primary, demote any existing primary first
+      // so the partial unique index isn't violated.
+      if (isPrimary) {
+        await tx.partnerContact.updateMany({
+          where: { partnerId: parsedPartnerId.data, isPrimary: true },
+          data: { isPrimary: false },
+        });
+      }
+
+      await tx.partnerContact.create({
+        data: {
+          partnerId: parsedPartnerId.data,
+          personId,
+          role: role || null,
+          isPrimary: isPrimary ?? false,
+          isActive: isActive ?? true,
+        },
+      });
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        errors: { personId: ["This person is already a contact here."] },
+        message: "Failed to add contact.",
+      };
+    }
+    console.error("Database Error adding partner contact:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to add contact.",
+    };
+  }
+
+  revalidateContacts(parsedPartnerId.data);
+  return { success: true, message: "Contact added successfully." };
+};
+
+const _updatePartnerContact = async (
+  contactId: string,
+  partnerId: string,
+  prevState: PartnerContactFormState,
+  formData: FormData,
+): Promise<PartnerContactFormState> => {
+  const parsedContactId = cuidSchema.safeParse(contactId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedContactId.success || !parsedPartnerId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  const raw = Object.fromEntries(formData.entries());
+  const validatedFields = PartnerContactFormSchema.safeParse({
+    ...raw,
+    isPrimary: formData.get("isPrimary") !== null,
+    isActive: formData.get("isActive") !== null,
+  });
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update contact.",
+    };
+  }
+
+  // personId is locked in edit mode, we don't change who the contact is.
+  const { role, isPrimary, isActive } = validatedFields.data;
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (isPrimary) {
+        // Demote any OTHER primary (not this row) before promoting this one.
+        await tx.partnerContact.updateMany({
+          where: {
+            partnerId: parsedPartnerId.data,
+            isPrimary: true,
+            id: { not: parsedContactId.data },
+          },
+          data: { isPrimary: false },
+        });
+      }
+
+      await tx.partnerContact.update({
+        where: { id: parsedContactId.data },
+        data: {
+          role: role || null,
+          isPrimary: isPrimary ?? false,
+          isActive: isActive ?? true,
+        },
+      });
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2025") {
+        return { message: "Contact not found." };
+      }
+    }
+    console.error("Database Error updating partner contact:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update contact.",
+    };
+  }
+
+  revalidateContacts(parsedPartnerId.data);
+  return { success: true, message: "Contact updated successfully." };
+};
+
+export type SetPrimaryResult = {
+  success: boolean;
+  message: string;
+  previousPrimary: { id: string; name: string } | null;
+  newPrimary: { id: string; name: string } | null;
+};
+
+const _setPrimaryContact = async (
+  contactId: string,
+  partnerId: string,
+): Promise<SetPrimaryResult> => {
+  const parsedContactId = cuidSchema.safeParse(contactId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedContactId.success || !parsedPartnerId.success) {
+    return {
+      success: false,
+      message: "Invalid ID format.",
+      previousPrimary: null,
+      newPrimary: null,
+    };
+  }
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      // Find the current primary (if any) BEFORE changing anything — this is
+      // what the toast reports and what Undo reverts to.
+      const current = await tx.partnerContact.findFirst({
+        where: { partnerId: parsedPartnerId.data, isPrimary: true },
+        select: { id: true, person: { select: { name: true } } },
+      });
+
+      // If the target is already primary, nothing to do.
+      if (current?.id === parsedContactId.data) {
+        return { previous: null, alreadyPrimary: true, newName: null };
+      }
+
+      // Demote the existing primary (if any), then promote the target.
+      if (current) {
+        await tx.partnerContact.update({
+          where: { id: current.id },
+          data: { isPrimary: false },
+        });
+      }
+
+      const promoted = await tx.partnerContact.update({
+        where: { id: parsedContactId.data },
+        data: { isPrimary: true, isActive: true },
+        select: { person: { select: { name: true } } },
+      });
+
+      return {
+        previous: current
+          ? { id: current.id, name: current.person.name }
+          : null,
+        alreadyPrimary: false,
+        newName: promoted.person.name,
+      };
+    });
+
+    if (result.alreadyPrimary) {
+      return {
+        success: true,
+        message: "This contact is already the primary.",
+        previousPrimary: null,
+        newPrimary: null,
+      };
+    }
+
+    revalidateContacts(parsedPartnerId.data);
+
+    return {
+      success: true,
+      message: result.previous
+        ? `Primary changed from ${result.previous.name} to ${result.newName}.`
+        : `${result.newName} set as primary contact.`,
+      previousPrimary: result.previous,
+      newPrimary: { id: parsedContactId.data, name: result.newName! },
+    };
+  } catch (error) {
+    console.error("Error setting primary contact:", error);
+    return {
+      success: false,
+      message: "Failed to set primary contact.",
+      previousPrimary: null,
+      newPrimary: null,
+    };
+  }
+};
+
+const _setContactActive = async (
+  contactId: string,
+  partnerId: string,
+  isActive: boolean,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedContactId = cuidSchema.safeParse(contactId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedContactId.success || !parsedPartnerId.success) {
+    return { success: false, message: "Invalid ID format." };
+  }
+
+  try {
+    await prisma.partnerContact.update({
+      where: { id: parsedContactId.data },
+      data: {
+        isActive,
+        // Deactivating a contact can't leave them as primary.
+        ...(isActive ? {} : { isPrimary: false }),
+      },
+    });
+  } catch (error) {
+    console.error("Error updating contact active status:", error);
+    return { success: false, message: "Failed to update contact." };
+  }
+
+  revalidateContacts(parsedPartnerId.data);
+  return {
+    success: true,
+    message: isActive ? "Contact reactivated." : "Contact deactivated.",
+  };
+};
+
+export const setPrimaryContact = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_setPrimaryContact);
+
+export const setContactActive = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_setContactActive);
+
+export const addPartnerContact = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_addPartnerContact);
+
+export const updatePartnerContact = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_updatePartnerContact);

--- a/app/lib/actions/partner-note-actions.tsx
+++ b/app/lib/actions/partner-note-actions.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PartnerNotePayload } from "@/app/lib/types";
+import {
+  deletePartnerNote,
+  restorePartnerNote,
+} from "@/app/lib/actions/partner-note.actions";
+import { toast } from "sonner";
+import { PartnerNoteForm } from "@/components/dashboard/partners-directory/notes/partner-note-form";
+
+interface PartnerNoteActionsProps {
+  note: PartnerNotePayload;
+  partnerId: string;
+}
+
+export function PartnerNoteActions({
+  note,
+  partnerId,
+}: PartnerNoteActionsProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deletePartnerNote(note.id, partnerId).then((data) => {
+        if (data?.message) {
+          toast.success(data.message, {
+            action: {
+              label: "Undo",
+              onClick: () => onRestore(),
+            },
+          });
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restorePartnerNote(note.id, partnerId).then((data) => {
+        if (data?.message) {
+          toast.success(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {note.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Edit Note</DialogTitle>
+          <DialogDescription>
+            Update the details for this note. Click update when you&apos;re
+            done.
+          </DialogDescription>
+        </DialogHeader>
+        <PartnerNoteForm
+          partnerId={partnerId}
+          onFormSubmit={() => setIsDialogOpen(false)}
+          note={note}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/lib/actions/partner-note.actions.ts
+++ b/app/lib/actions/partner-note.actions.ts
@@ -1,0 +1,173 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import {
+  RequirePermission,
+  SessionUser,
+  withAuthenticatedUser,
+} from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { PartnerNoteFormSchema } from "../zod-schemas/partners-directory.schemas";
+import { z } from "zod";
+
+export type PartnerNoteFormState = {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    content?: string[];
+  };
+};
+
+const revalidateNotes = (partnerId: string) => {
+  revalidatePath(`/dashboard/partners-directory/${partnerId}`);
+  revalidatePath(`/dashboard/partners-directory/${partnerId}/notes`);
+};
+
+const _createPartnerNote = async (
+  user: SessionUser,
+  partnerId: string,
+  prevState: PartnerNoteFormState,
+  formData: FormData,
+): Promise<PartnerNoteFormState> => {
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+
+  if (!parsedPartnerId.success) {
+    return { message: "Invalid partner ID format." };
+  }
+
+  const validatedFields = PartnerNoteFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create note.",
+    };
+  }
+
+  try {
+    await prisma.partnerNote.create({
+      data: {
+        content: validatedFields.data.content,
+        partnerId: parsedPartnerId.data,
+        authorId: user.personId,
+      },
+    });
+  } catch (error) {
+    console.error("Database Error creating partner note:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create note.",
+    };
+  }
+
+  revalidateNotes(parsedPartnerId.data);
+  return { success: true, message: "Note created successfully." };
+};
+
+const _updatePartnerNote = async (
+  noteId: string,
+  partnerId: string,
+  prevState: PartnerNoteFormState,
+  formData: FormData,
+): Promise<PartnerNoteFormState> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedNoteId.success || !parsedPartnerId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  const validatedFields = PartnerNoteFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update note.",
+    };
+  }
+
+  try {
+    await prisma.partnerNote.update({
+      where: { id: parsedNoteId.data },
+      data: { content: validatedFields.data.content },
+    });
+  } catch (error) {
+    console.error("Database Error updating partner note:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update note.",
+    };
+  }
+
+  revalidateNotes(parsedPartnerId.data);
+  return { success: true, message: "Note updated successfully." };
+};
+
+const _deletePartnerNote = async (
+  noteId: string,
+  partnerId: string,
+): Promise<{ message: string }> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedNoteId.success || !parsedPartnerId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  try {
+    await prisma.partnerNote.update({
+      where: { id: parsedNoteId.data },
+      data: { deletedAt: new Date() },
+    });
+  } catch (error) {
+    console.error("Database Error deleting partner note:", error);
+    return { message: "Failed to delete note." };
+  }
+
+  revalidateNotes(parsedPartnerId.data);
+  return { message: "Note deleted." };
+};
+
+const _restorePartnerNote = async (
+  noteId: string,
+  partnerId: string,
+): Promise<{ message: string }> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPartnerId = cuidSchema.safeParse(partnerId);
+  if (!parsedNoteId.success || !parsedPartnerId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  try {
+    await prisma.partnerNote.update({
+      where: { id: parsedNoteId.data },
+      data: { deletedAt: null },
+    });
+  } catch (error) {
+    console.error("Database Error restoring partner note:", error);
+    return { message: "Failed to restore note." };
+  }
+
+  revalidateNotes(parsedPartnerId.data);
+  return { message: "Note restored." };
+};
+
+export const createPartnerNote = withAuthenticatedUser(
+  RequirePermission(AppPermissions.PARTNERS_MANAGE)(_createPartnerNote),
+);
+
+export const updatePartnerNote = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_updatePartnerNote);
+
+export const deletePartnerNote = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_deletePartnerNote);
+
+export const restorePartnerNote = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_restorePartnerNote);

--- a/app/lib/actions/partner.actions.ts
+++ b/app/lib/actions/partner.actions.ts
@@ -1,0 +1,177 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { PartnerFormState } from "../form-state-types";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { PartnerFormSchema } from "../zod-schemas/partners-directory.schemas";
+import { z } from "zod";
+
+const _createPartner = async (
+  prevState: PartnerFormState,
+  formData: FormData,
+): Promise<PartnerFormState> => {
+  const raw = Object.fromEntries(formData.entries());
+  
+  const validatedFields = PartnerFormSchema.safeParse({
+    ...raw,
+    // Checkboxes submit "on" or are absent; normalize to boolean.
+    isActive: formData.get("isActive") !== null,
+  });
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create partner.",
+    };
+  }
+
+  const {
+    name,
+    type,
+    email,
+    phone,
+    website,
+    address,
+    city,
+    state,
+    zipCode,
+    isActive,
+    notes,
+  } = validatedFields.data;
+
+  let newPartnerId: string;
+
+  try {
+    const partner = await prisma.partner.create({
+      data: {
+        name,
+        type,
+        email: email || null,
+        phone: phone || null,
+        website: website || null,
+        address: address || null,
+        city: city || null,
+        state: state || null,
+        zipCode: zipCode || null,
+        isActive: isActive ?? true,
+        notes: notes || null,
+      },
+    });
+    newPartnerId = partner.id;
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        errors: { name: ["A partner with this name already exists."] },
+        message: "Failed to create partner.",
+      };
+    }
+    console.error("Database Error creating partner:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create partner.",
+    };
+  }
+
+  revalidatePath("/dashboard/partners-directory");
+  redirect(`/dashboard/partners-directory/${newPartnerId}`);
+};
+
+const _updatePartner = async (
+  partnerId: string,
+  prevState: PartnerFormState,
+  formData: FormData,
+): Promise<PartnerFormState> => {
+  const parsedId = cuidSchema.safeParse(partnerId);
+  if (!parsedId.success) {
+    return { message: "Invalid partner ID format." };
+  }
+
+  const raw = Object.fromEntries(formData.entries());
+  const validatedFields = PartnerFormSchema.safeParse({
+    ...raw,
+    isActive: formData.get("isActive") !== null,
+  });
+
+  if (!validatedFields.success) {
+    return {
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update partner.",
+    };
+  }
+
+  const {
+    name,
+    type,
+    email,
+    phone,
+    website,
+    address,
+    city,
+    state,
+    zipCode,
+    isActive,
+    notes,
+  } = validatedFields.data;
+
+  try {
+    await prisma.partner.update({
+      where: { id: parsedId.data },
+      data: {
+        name,
+        type,
+        email: email || null,
+        phone: phone || null,
+        website: website || null,
+        address: address || null,
+        city: city || null,
+        state: state || null,
+        zipCode: zipCode || null,
+        isActive: isActive ?? true,
+        notes: notes || null,
+      },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        return {
+          errors: { name: ["A partner with this name already exists."] },
+          message: "Failed to update partner.",
+        };
+      }
+      if (error.code === "P2025") {
+        return { message: "Partner not found." };
+      }
+    }
+    console.error("Database Error updating partner:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update partner.",
+    };
+  }
+
+  revalidatePath("/dashboard/partners-directory");
+  revalidatePath(`/dashboard/partners-directory/${parsedId.data}`);
+
+  const returnTo = formData.get("returnTo");
+  redirect(
+    typeof returnTo === "string" && returnTo
+      ? returnTo
+      : `/dashboard/partners-directory/${parsedId.data}`,
+  );
+};
+
+export const createPartner = RequirePermission(AppPermissions.PARTNERS_MANAGE)(
+  _createPartner,
+);
+
+export const updatePartner = RequirePermission(AppPermissions.PARTNERS_MANAGE)(
+  _updatePartner,
+);

--- a/app/lib/actions/person-note.actions.ts
+++ b/app/lib/actions/person-note.actions.ts
@@ -1,0 +1,174 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import {
+  RequirePermission,
+  SessionUser,
+  withAuthenticatedUser,
+} from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { PersonNoteFormSchema } from "../zod-schemas/people-directory.schemas";
+import { z } from "zod";
+
+export type PersonNoteFormState = {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    content?: string[];
+  };
+};
+
+const revalidateNotes = (personId: string) => {
+  revalidatePath(`/dashboard/people-directory/${personId}`);
+  revalidatePath(`/dashboard/people-directory/${personId}/notes`);
+};
+
+const _createPersonNote = async (
+  user: SessionUser,
+  personId: string, // the SUBJECT person (note is about them)
+  prevState: PersonNoteFormState,
+  formData: FormData,
+): Promise<PersonNoteFormState> => {
+  const parsedPersonId = cuidSchema.safeParse(personId);
+  if (!parsedPersonId.success) {
+    return { success: false, message: "Invalid person ID format." };
+  }
+
+  const validatedFields = PersonNoteFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create note.",
+    };
+  }
+
+  try {
+    await prisma.personNote.create({
+      data: {
+        content: validatedFields.data.content,
+        personId: parsedPersonId.data, // subject
+        authorId: user.personId, // author = session user
+      },
+    });
+  } catch (error) {
+    console.error("Database Error creating person note:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create note.",
+    };
+  }
+
+  revalidateNotes(parsedPersonId.data);
+  return { success: true, message: "Note created successfully." };
+};
+
+const _updatePersonNote = async (
+  noteId: string,
+  personId: string,
+  prevState: PersonNoteFormState,
+  formData: FormData,
+): Promise<PersonNoteFormState> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPersonId = cuidSchema.safeParse(personId);
+  if (!parsedNoteId.success || !parsedPersonId.success) {
+    return { success: false, message: "Invalid ID format." };
+  }
+
+  const validatedFields = PersonNoteFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update note.",
+    };
+  }
+
+  try {
+    await prisma.personNote.update({
+      where: { id: parsedNoteId.data },
+      data: { content: validatedFields.data.content },
+    });
+  } catch (error) {
+    console.error("Database Error updating person note:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update note.",
+    };
+  }
+
+  revalidateNotes(parsedPersonId.data);
+  return { success: true, message: "Note updated successfully." };
+};
+
+const _deletePersonNote = async (
+  noteId: string,
+  personId: string,
+): Promise<{ message: string }> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPersonId = cuidSchema.safeParse(personId);
+  if (!parsedNoteId.success || !parsedPersonId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  try {
+    await prisma.personNote.update({
+      where: { id: parsedNoteId.data },
+      data: { deletedAt: new Date() },
+    });
+  } catch (error) {
+    console.error("Database Error deleting person note:", error);
+    return { message: "Failed to delete note." };
+  }
+
+  revalidateNotes(parsedPersonId.data);
+  return { message: "Note deleted." };
+};
+
+const _restorePersonNote = async (
+  noteId: string,
+  personId: string,
+): Promise<{ message: string }> => {
+  const parsedNoteId = cuidSchema.safeParse(noteId);
+  const parsedPersonId = cuidSchema.safeParse(personId);
+  if (!parsedNoteId.success || !parsedPersonId.success) {
+    return { message: "Invalid ID format." };
+  }
+
+  try {
+    await prisma.personNote.update({
+      where: { id: parsedNoteId.data },
+      data: { deletedAt: null },
+    });
+  } catch (error) {
+    console.error("Database Error restoring person note:", error);
+    return { message: "Failed to restore note." };
+  }
+
+  revalidateNotes(parsedPersonId.data);
+  return { message: "Note restored." };
+};
+
+export const createPersonNote = withAuthenticatedUser(
+  RequirePermission(AppPermissions.PERSONS_MANAGE)(_createPersonNote),
+);
+
+export const updatePersonNote = RequirePermission(
+  AppPermissions.PERSONS_MANAGE,
+)(_updatePersonNote);
+
+export const deletePersonNote = RequirePermission(
+  AppPermissions.PERSONS_MANAGE,
+)(_deletePersonNote);
+
+export const restorePersonNote = RequirePermission(
+  AppPermissions.PERSONS_MANAGE,
+)(_restorePersonNote);

--- a/app/lib/actions/person.actions.ts
+++ b/app/lib/actions/person.actions.ts
@@ -13,6 +13,7 @@ import {
 } from "../auth/protected-actions";
 import { AppPermissions } from "@/app/lib/auth/permissions";
 import { PersonFormSchema } from "../zod-schemas/people-directory.schemas";
+import { z } from "zod";
 
 const _createPerson = async (
   prevState: PersonFormState,
@@ -24,7 +25,7 @@ const _createPerson = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to create person.",
     };
   }
@@ -84,7 +85,7 @@ const _updatePerson = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to update person.",
     };
   }
@@ -146,7 +147,7 @@ const _updateMyProfile = async (
 
   if (!validatedFields.success) {
     return {
-      errors: validatedFields.error.flatten().fieldErrors,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
       message: "Missing or invalid fields. Failed to update profile.",
     };
   }

--- a/app/lib/data/animals/animal-note.data.ts
+++ b/app/lib/data/animals/animal-note.data.ts
@@ -8,7 +8,7 @@ import z from "zod";
 import { AppPermissions } from "@/app/lib/auth/permissions";
 import { RequirePermission } from "../../auth/protected-actions";
 
-export type FetchAnimalNotePayload = Prisma.NoteGetPayload<{
+export type FetchAnimalNotePayload = Prisma.AnimalNoteGetPayload<{
   select: {
     id: true;
     category: true;
@@ -16,7 +16,7 @@ export type FetchAnimalNotePayload = Prisma.NoteGetPayload<{
   };
 }>;
 
-export type NotePayload = Prisma.NoteGetPayload<{
+export type NotePayload = Prisma.AnimalNoteGetPayload<{
   select: {
     id: true;
     content: true;
@@ -70,13 +70,13 @@ const _fetchAnimalNotes = async (
     showDeleted: includeDeleted,
   } = validatedArgs.data;
   // Determine the sorting order for the query, defaulting to newest first
-  const orderBy: Prisma.NoteOrderByWithRelationInput = (() => {
+  const orderBy: Prisma.AnimalNoteOrderByWithRelationInput = (() => {
     if (!sort) return { createdAt: "desc" };
     const [id, dir] = sort.split(".");
     return { [id]: dir === "desc" ? "desc" : "asc" };
   })();
   // Construct the 'where' clause for the Prisma query based on filters
-  const whereClause: Prisma.NoteWhereInput = {
+  const whereClause: Prisma.AnimalNoteWhereInput = {
     animalId: animalId,
     ...(category && {
       category: { in: category.split(",") as NoteCategory[] },
@@ -88,8 +88,8 @@ const _fetchAnimalNotes = async (
     const offset = (currentPage - 1) * NOTES_PER_PAGE;
     // Use a transaction to fetch the total count and the notes data in one go
     const [totalCount, notes] = await prisma.$transaction([
-      prisma.note.count({ where: whereClause }),
-      prisma.note.findMany({
+      prisma.animalNote.count({ where: whereClause }),
+      prisma.animalNote.findMany({
         where: whereClause,
         select: {
           id: true,

--- a/app/lib/data/animals/animal-note.data.ts
+++ b/app/lib/data/animals/animal-note.data.ts
@@ -37,7 +37,7 @@ const AnimalNotesSchema = z.object({
   animalId: cuidSchema,
   category: z.string().optional(),
   sort: z.string().optional(),
-  showDeleted: z.boolean().optional(),
+  status: z.string().optional(),
 });
 
 const NOTES_PER_PAGE = 10;
@@ -47,46 +47,52 @@ const _fetchAnimalNotes = async (
   categoryInput: string | undefined,
   sortInput: string | undefined,
   inputAnimalId: string,
-  showDeleted: boolean = false
+  statusInput: string | undefined,
 ): Promise<{ notes: NotePayload[]; totalPages: number }> => {
-  // Validate and parse the input arguments using the Zod schema
   const validatedArgs = AnimalNotesSchema.safeParse({
     currentPage: currentPageInput,
     category: categoryInput,
     sort: sortInput,
     animalId: inputAnimalId,
-    showDeleted,
+    status: statusInput,
   });
-  // If validation fails, log the error and throw an exception
   if (!validatedArgs.success) {
     throw new Error("Invalid arguments for fetching notes.");
   }
 
-  const {
-    currentPage,
-    category,
-    sort,
-    animalId,
-    showDeleted: includeDeleted,
-  } = validatedArgs.data;
-  // Determine the sorting order for the query, defaulting to newest first
+  const { currentPage, category, sort, animalId, status } = validatedArgs.data;
+
   const orderBy: Prisma.AnimalNoteOrderByWithRelationInput = (() => {
     if (!sort) return { createdAt: "desc" };
     const [id, dir] = sort.split(".");
     return { [id]: dir === "desc" ? "desc" : "asc" };
   })();
-  // Construct the 'where' clause for the Prisma query based on filters
+
+  // Status filter: deleted notes show only when "deleted" is selected.
+  // Default (nothing) and "active" only → active notes. Both → all.
+  const selected = status ? status.split(",").filter(Boolean) : [];
+  const wantsActive = selected.includes("active");
+  const wantsDeleted = selected.includes("deleted");
+
+  let deletedFilter: Prisma.AnimalNoteWhereInput = {};
+  if (wantsDeleted && !wantsActive) {
+    deletedFilter = { deletedAt: { not: null } }; // deleted only
+  } else if (wantsActive && wantsDeleted) {
+    deletedFilter = {}; // both → all
+  } else {
+    deletedFilter = { deletedAt: null }; // default & active-only → active
+  }
+
   const whereClause: Prisma.AnimalNoteWhereInput = {
     animalId: animalId,
     ...(category && {
       category: { in: category.split(",") as NoteCategory[] },
     }),
-    ...(includeDeleted ? {} : { deletedAt: null }),
+    ...deletedFilter,
   };
+
   try {
-    // Calculate the offset for pagination
     const offset = (currentPage - 1) * NOTES_PER_PAGE;
-    // Use a transaction to fetch the total count and the notes data in one go
     const [totalCount, notes] = await prisma.$transaction([
       prisma.animalNote.count({ where: whereClause }),
       prisma.animalNote.findMany({
@@ -105,11 +111,11 @@ const _fetchAnimalNotes = async (
           },
         },
         orderBy: orderBy,
-        take: NOTES_PER_PAGE, // Limit the number of records returned
-        skip: offset, // Skip records for pagination
+        take: NOTES_PER_PAGE,
+        skip: offset,
       }),
     ]);
-    // Calculate the total number of pages
+
     const totalPages = Math.ceil(totalCount / NOTES_PER_PAGE);
     return { notes, totalPages };
   } catch (error) {
@@ -119,5 +125,5 @@ const _fetchAnimalNotes = async (
 };
 
 export const fetchAnimalNotes = RequirePermission(
-  AppPermissions.ANIMAL_NOTE_READ
+  AppPermissions.ANIMAL_NOTE_READ,
 )(_fetchAnimalNotes);

--- a/app/lib/data/animals/outcome.data.ts
+++ b/app/lib/data/animals/outcome.data.ts
@@ -170,7 +170,7 @@ export const _fetchOutcomes = async (
 
   try {
     const offset = (currentPage - 1) * pageSize;
-    const [totalCount, outcomes] = await prisma.$transaction([
+    const [totalCount, outcomes] = await Promise.all([
       prisma.outcome.count({ where: whereClause }),
       prisma.outcome.findMany({
         where: whereClause,

--- a/app/lib/data/partners-directory/partner-animal-history.data.ts
+++ b/app/lib/data/partners-directory/partner-animal-history.data.ts
@@ -1,0 +1,102 @@
+import { prisma } from "@/app/lib/prisma";
+import { IntakeType, OutcomeType } from "@prisma/client";
+import { cuidSchema } from "../../zod-schemas/common.schemas";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+
+export type PartnerTransferDirection = "TRANSFER_IN" | "TRANSFER_OUT";
+
+export type PartnerAnimalHistoryEntry = {
+  direction: PartnerTransferDirection;
+  date: Date | null;
+  animal: {
+    id: string;
+    name: string;
+    species: { name: string };
+    animalImages: { url: string }[];
+    listingStatus: string;
+  };
+  intakeType?: IntakeType;
+  outcomeType?: OutcomeType;
+};
+
+const animalSelect = {
+  id: true,
+  name: true,
+  listingStatus: true,
+  species: { select: { name: true } },
+  animalImages: {
+    select: { url: true },
+    orderBy: { createdAt: "asc" as const },
+    take: 1,
+  },
+} as const;
+
+const _fetchPartnerAnimalHistory = async (
+  inputPartnerId: string,
+): Promise<{ history: PartnerAnimalHistoryEntry[] }> => {
+  const parsedId = cuidSchema.safeParse(inputPartnerId);
+
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+
+  const partnerId = parsedId.data;
+
+  try {
+    const partner = await prisma.partner.findUnique({
+      where: { id: partnerId },
+      select: {
+        transferredInAnimals: {
+          select: {
+            intakeDate: true,
+            type: true,
+            animal: { select: animalSelect },
+          },
+        },
+        transferredOutAnimals: {
+          select: {
+            outcomeDate: true,
+            type: true,
+            animal: { select: animalSelect },
+          },
+        },
+      },
+    });
+
+    if (!partner) {
+      return { history: [] };
+    }
+
+    const history: PartnerAnimalHistoryEntry[] = [
+      ...partner.transferredInAnimals.map((intake) => ({
+        direction: "TRANSFER_IN" as const,
+        date: intake.intakeDate,
+        animal: intake.animal,
+        intakeType: intake.type,
+      })),
+      ...partner.transferredOutAnimals.map((outcome) => ({
+        direction: "TRANSFER_OUT" as const,
+        date: outcome.outcomeDate,
+        animal: outcome.animal,
+        outcomeType: outcome.type,
+      })),
+    ];
+
+    history.sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return b.date.getTime() - a.date.getTime();
+    });
+
+    return { history };
+  } catch (error) {
+    console.error("Error fetching partner animal history.", error);
+    throw new Error("Could not fetch partner animal history.");
+  }
+};
+
+export const fetchPartnerAnimalHistory = RequirePermission(
+  AppPermissions.PARTNERS_READ,
+)(_fetchPartnerAnimalHistory);

--- a/app/lib/data/partners-directory/partner-contacts.data.ts
+++ b/app/lib/data/partners-directory/partner-contacts.data.ts
@@ -1,0 +1,101 @@
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../../zod-schemas/common.schemas";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { PartnerContactsPayload, LinkablePersonPayload } from "../../types";
+
+const _fetchPartnerContacts = async (
+  inputPartnerId: string,
+): Promise<{ contacts: PartnerContactsPayload[] }> => {
+  const parsedId = cuidSchema.safeParse(inputPartnerId);
+
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+
+  const partnerId = parsedId.data;
+
+  try {
+    const contacts = await prisma.partnerContact.findMany({
+      where: { partnerId },
+      orderBy: [
+        { isPrimary: "desc" }, // primary first
+        { isActive: "desc" }, // then active before inactive
+        { createdAt: "asc" }, // then oldest first
+      ],
+      select: {
+        id: true,
+        role: true,
+        isPrimary: true,
+        isActive: true,
+        person: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            phone: true,
+          },
+        },
+      },
+    });
+
+    return { contacts };
+  } catch (error) {
+    console.error("Error fetching partner contacts.", error);
+    throw new Error("Could not fetch partner contacts.");
+  }
+};
+
+const _fetchLinkablePeople = async (
+  inputPartnerId: string,
+): Promise<{ people: LinkablePersonPayload[] }> => {
+  const parsedId = cuidSchema.safeParse(inputPartnerId);
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+  const partnerId = parsedId.data;
+
+  try {
+    const rows = await prisma.person.findMany({
+      where: {
+        // Exclude people who are already ACTIVE contacts at this partner.
+        NOT: {
+          partnerContacts: { some: { partnerId, isActive: true } },
+        },
+      },
+      orderBy: { name: "asc" },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        phone: true,
+        partnerContacts: {
+          where: { partnerId },
+          select: { isActive: true },
+          take: 1,
+        },
+      },
+    });
+
+    const people = rows.map((p) => ({
+      id: p.id,
+      name: p.name,
+      email: p.email,
+      phone: p.phone,
+      isDeactivatedContactHere: p.partnerContacts.length > 0,
+    }));
+
+    return { people };
+  } catch (error) {
+    console.error("Error fetching linkable people.", error);
+    throw new Error("Could not fetch people.");
+  }
+};
+
+export const fetchLinkablePeople = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_fetchLinkablePeople);
+
+export const fetchPartnerContacts = RequirePermission(
+  AppPermissions.PARTNERS_READ,
+)(_fetchPartnerContacts);

--- a/app/lib/data/partners-directory/partner-notes.data.ts
+++ b/app/lib/data/partners-directory/partner-notes.data.ts
@@ -1,0 +1,100 @@
+import { prisma } from "@/app/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { cuidSchema } from "../../zod-schemas/common.schemas";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { PartnerNotesParamsSchema } from "../../zod-schemas/partners-directory.schemas";
+import { PartnerNotePayload } from "../../types";
+
+const PAGE_SIZE = 10;
+
+const _fetchPartnerNotes = async (
+  partnerIdInput: string,
+  currentPageInput: number,
+  sortInput: string | undefined,
+  statusInput: string | undefined,
+): Promise<{
+  notes: PartnerNotePayload[];
+  totalPages: number;
+  totalRows: number;
+}> => {
+  const parsedId = cuidSchema.safeParse(partnerIdInput);
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+
+  const validatedArgs = PartnerNotesParamsSchema.safeParse({
+    currentPage: currentPageInput,
+    sort: sortInput,
+    status: statusInput,
+  });
+  if (!validatedArgs.success) {
+    throw new Error("Invalid arguments for fetching partner notes.");
+  }
+  const { currentPage, sort, status } = validatedArgs.data;
+  const partnerId = parsedId.data;
+
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  // Sort: newest/oldest by createdAt; default newest first.
+  const orderBy: Prisma.PartnerNoteOrderByWithRelationInput = (() => {
+    if (!sort) return { createdAt: "desc" };
+    const [field, direction] = sort.split(".");
+    const dir = direction === "asc" ? "asc" : "desc";
+    if (field === "createdAt") return { createdAt: dir };
+    return { createdAt: "desc" };
+  })();
+
+  // Status filter: deleted notes shown only when "deleted" is selected.
+  const selected = status ? status.split(",").filter(Boolean) : [];
+  const wantsActive = selected.includes("active");
+  const wantsDeleted = selected.includes("deleted");
+
+  let deletedFilter: Prisma.PartnerNoteWhereInput = {};
+  if (wantsDeleted && !wantsActive) {
+    deletedFilter = { deletedAt: { not: null } }; // deleted only
+  } else if (wantsActive && wantsDeleted) {
+    deletedFilter = {}; // both → all
+  } else {
+    deletedFilter = { deletedAt: null }; // default & active-only → active
+  }
+
+  const whereClause: Prisma.PartnerNoteWhereInput = {
+    partnerId,
+    ...deletedFilter,
+  };
+
+  try {
+    const [totalRows, notes] = await prisma.$transaction([
+      prisma.partnerNote.count({ where: whereClause }),
+      prisma.partnerNote.findMany({
+        where: whereClause,
+        orderBy,
+        skip: offset,
+        take: PAGE_SIZE,
+        select: {
+          id: true,
+          content: true,
+          author: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          createdAt: true,
+          deletedAt: true,
+        },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(totalRows / PAGE_SIZE);
+    return { notes, totalPages, totalRows };
+  } catch (error) {
+    console.error("Error fetching partner notes.", error);
+    throw new Error("Error fetching partner notes.");
+  }
+};
+
+export const fetchPartnerNotes = RequirePermission(AppPermissions.PARTNERS_READ)(
+  _fetchPartnerNotes,
+);

--- a/app/lib/data/partners-directory/partners-directory.data.ts
+++ b/app/lib/data/partners-directory/partners-directory.data.ts
@@ -1,0 +1,241 @@
+import { prisma } from "@/app/lib/prisma";
+import { PartnerType, Prisma } from "@prisma/client";
+import { RequirePermission } from "../../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { PartnersDirectoryParamsSchema } from "../../zod-schemas/partners-directory.schemas";
+import { PartnerFormPayload, PartnersDirectoryPayload, PartnerSectionCardPayload } from "../../types";
+import { cuidSchema } from "../../zod-schemas/common.schemas";
+
+const _fetchPartners = async (
+  queryInput: string,
+  currentPageInput: number,
+  sortInput: string | undefined,
+  pageSizeInput: number,
+  typeInput: string | undefined,
+  statusInput: string | undefined,
+): Promise<{
+  partners: PartnersDirectoryPayload[];
+  totalPages: number;
+  totalRows: number;
+}> => {
+  const validatedArgs = PartnersDirectoryParamsSchema.safeParse({
+    query: queryInput,
+    currentPage: currentPageInput,
+    sort: sortInput,
+    pageSize: pageSizeInput,
+    type: typeInput,
+    status: statusInput,
+  });
+
+  if (!validatedArgs.success) {
+    throw new Error("Invalid arguments for fetching partners.");
+  }
+  const { query, currentPage, sort, pageSize, type, status } =
+    validatedArgs.data;
+
+  const offset = (currentPage - 1) * pageSize;
+
+  // Dynamically set the sorting order
+  const orderBy: Prisma.PartnerOrderByWithRelationInput = (() => {
+    if (!sort) return { name: "asc" };
+    const [field, direction] = sort.split(".");
+    const dir = direction === "asc" ? "asc" : "desc";
+
+    switch (field) {
+      case "name":
+        return { name: dir };
+      case "type":
+        return { type: dir };
+      case "email":
+        return { email: dir };
+      case "city":
+        return { city: dir };
+      case "state":
+        return { state: dir };
+      case "createdAt":
+        return { createdAt: dir };
+      default:
+        return { name: "asc" };
+    }
+  })();
+
+  const whereClause: Prisma.PartnerWhereInput = {
+    AND: [
+      {
+        OR: [
+          { name: { contains: query, mode: "insensitive" } },
+          { email: { contains: query, mode: "insensitive" } },
+          { city: { contains: query, mode: "insensitive" } },
+        ],
+      },
+    ],
+  };
+
+  // Type faceted filter: comma-separated PartnerType values.
+  // Only narrow when a strict, non-empty subset of valid types is selected.
+  if (type) {
+    const allTypes = Object.values(PartnerType) as string[];
+    const selected = type
+      .split(",")
+      .filter((t) => allTypes.includes(t)) as PartnerType[];
+
+    if (selected.length > 0 && selected.length < allTypes.length) {
+      (whereClause.AND as Prisma.PartnerWhereInput[]).push({
+        type: { in: selected },
+      });
+    }
+  }
+
+  // Status faceted filter: "active" / "inactive".
+  // Only narrow when exactly one of the two is chosen.
+  if (status) {
+    const selected = status.split(",").filter(Boolean);
+    const wantsActive = selected.includes("active");
+    const wantsInactive = selected.includes("inactive");
+
+    if (wantsActive && !wantsInactive) {
+      (whereClause.AND as Prisma.PartnerWhereInput[]).push({ isActive: true });
+    } else if (wantsInactive && !wantsActive) {
+      (whereClause.AND as Prisma.PartnerWhereInput[]).push({ isActive: false });
+    }
+  }
+
+  try {
+    const [totalRows, partners] = await prisma.$transaction([
+      prisma.partner.count({ where: whereClause }),
+      prisma.partner.findMany({
+        where: whereClause,
+        orderBy,
+        skip: offset,
+        take: pageSize,
+        select: {
+          id: true,
+          name: true,
+          type: true,
+          email: true,
+          phone: true,
+          website: true,
+          city: true,
+          state: true,
+          isActive: true,
+          _count: {
+            select: {
+              contacts: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(totalRows / pageSize);
+
+    return { partners, totalPages, totalRows };
+  } catch (error) {
+    console.error("Error fetching partners.", error);
+    throw new Error("Error fetching partners.");
+  }
+};
+
+const _fetchPartnerForEdit = async (
+  id: string,
+): Promise<PartnerFormPayload | null> => {
+  const parsedId = cuidSchema.safeParse(id);
+
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+
+  try {
+    const partner = await prisma.partner.findUnique({
+      where: { id: parsedId.data },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        email: true,
+        phone: true,
+        website: true,
+        address: true,
+        city: true,
+        state: true,
+        zipCode: true,
+        isActive: true,
+        notes: true,
+      },
+    });
+
+    return partner;
+  } catch (error) {
+    console.error("Error fetching partner for edit.", error);
+    throw new Error("Error fetching partner data.");
+  }
+};
+
+const _fetchSectionCardsPartnerData = async (
+  id: string,
+): Promise<PartnerSectionCardPayload | null> => {
+  const parsedId = cuidSchema.safeParse(id);
+
+  if (!parsedId.success) {
+    throw new Error("Invalid partner ID format.");
+  }
+
+  const validatedPartnerId = parsedId.data;
+
+  try {
+    const partner = await prisma.partner.findUnique({
+      where: { id: validatedPartnerId },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+        email: true,
+        phone: true,
+        website: true,
+        address: true,
+        city: true,
+        state: true,
+        zipCode: true,
+        isActive: true,
+        notes: true,
+        // Deterministic primary contact, at most one exists (DB-enforced)
+        contacts: {
+          where: { isPrimary: true, isActive: true },
+          orderBy: { createdAt: "asc" },
+          take: 1,
+          select: {
+            role: true,
+            person: {
+              select: { id: true, name: true, email: true, phone: true },
+            },
+          },
+        },
+        _count: {
+          select: {
+            contacts: true,
+            transferredInAnimals: true,
+            transferredOutAnimals: true,
+            partnerNotes: true,
+          },
+        },
+      },
+    });
+
+    return partner;
+  } catch (error) {
+    console.error("Error fetching partner by ID.", error);
+    throw new Error("Error fetching partner details.");
+  }
+};
+
+export const fetchSectionCardsPartnerData = RequirePermission(
+  AppPermissions.PARTNERS_READ,
+)(_fetchSectionCardsPartnerData);
+
+export const fetchPartnerForEdit = RequirePermission(
+  AppPermissions.PARTNERS_MANAGE,
+)(_fetchPartnerForEdit);
+
+export const fetchPartners = RequirePermission(AppPermissions.PARTNERS_READ)(
+  _fetchPartners,
+);

--- a/app/lib/data/people-directory/people-directory.data.ts
+++ b/app/lib/data/people-directory/people-directory.data.ts
@@ -175,7 +175,7 @@ const _fetchSectionCardsPersonData = async (
             reclaimedAnimalsAsOwner: true,
             tasksAssigned: true,
             tasksCreated: true,
-            notesAuthored: true,
+            animalNotesAuthored: true,
             processedIntakes: true,
             processedOutcomes: true,
             Assessment: true,
@@ -292,9 +292,9 @@ export const fetchMyProfile = withAuthenticatedUser(
   RequirePermission(AppPermissions.MY_PROFILE_UPDATE)(_fetchMyProfile),
 );
 
-export const fetchPersonForEdit = RequirePermission(AppPermissions.PERSONS_MANAGE)(
-  _fetchPersonForEdit,
-);
+export const fetchPersonForEdit = RequirePermission(
+  AppPermissions.PERSONS_MANAGE,
+)(_fetchPersonForEdit);
 
 export const fetchSectionCardsPersonData = RequirePermission(
   AppPermissions.PERSONS_READ,

--- a/app/lib/data/people-directory/person-activity.data.ts
+++ b/app/lib/data/people-directory/person-activity.data.ts
@@ -119,7 +119,7 @@ const _fetchPersonActivity = async (
           orderBy: { createdAt: "desc" },
           take: PER_SOURCE_LIMIT,
         },
-        notesAuthored: {
+        animalNotesAuthored: {
           where: { deletedAt: null },
           select: {
             createdAt: true,
@@ -175,7 +175,7 @@ const _fetchPersonActivity = async (
         title: task.title,
         status: task.status,
       })),
-      ...person.notesAuthored.map((note) => ({
+      ...person.animalNotesAuthored.map((note) => ({
         kind: "NOTE_AUTHORED" as const,
         date: note.createdAt,
         animal: note.animal,

--- a/app/lib/data/people-directory/person-notes.data.ts
+++ b/app/lib/data/people-directory/person-notes.data.ts
@@ -1,0 +1,98 @@
+import { prisma } from "@/app/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { cuidSchema } from "../../zod-schemas/common.schemas";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { PersonNotesParamsSchema } from "../../zod-schemas/people-directory.schemas";
+import { PersonNotePayload } from "../../types";
+
+const PAGE_SIZE = 10;
+
+const _fetchPersonNotes = async (
+  personIdInput: string,
+  currentPageInput: number,
+  sortInput: string | undefined,
+  statusInput: string | undefined,
+): Promise<{
+  notes: PersonNotePayload[];
+  totalPages: number;
+  totalRows: number;
+}> => {
+  const parsedId = cuidSchema.safeParse(personIdInput);
+  if (!parsedId.success) {
+    throw new Error("Invalid person ID format.");
+  }
+
+  const validatedArgs = PersonNotesParamsSchema.safeParse({
+    currentPage: currentPageInput,
+    sort: sortInput,
+    status: statusInput,
+  });
+  if (!validatedArgs.success) {
+    throw new Error("Invalid arguments for fetching person notes.");
+  }
+  const { currentPage, sort, status } = validatedArgs.data;
+  const personId = parsedId.data;
+
+  const offset = (currentPage - 1) * PAGE_SIZE;
+
+  const orderBy: Prisma.PersonNoteOrderByWithRelationInput = (() => {
+    if (!sort) return { createdAt: "desc" };
+    const [field, direction] = sort.split(".");
+    const dir = direction === "asc" ? "asc" : "desc";
+    if (field === "createdAt") return { createdAt: dir };
+    return { createdAt: "desc" };
+  })();
+
+  const selected = status ? status.split(",").filter(Boolean) : [];
+  const wantsActive = selected.includes("active");
+  const wantsDeleted = selected.includes("deleted");
+
+  let deletedFilter: Prisma.PersonNoteWhereInput = {};
+  if (wantsDeleted && !wantsActive) {
+    deletedFilter = { deletedAt: { not: null } };
+  } else if (wantsActive && wantsDeleted) {
+    deletedFilter = {};
+  } else {
+    deletedFilter = { deletedAt: null };
+  }
+
+  const whereClause: Prisma.PersonNoteWhereInput = {
+    personId,
+    ...deletedFilter,
+  };
+
+  try {
+    const [totalRows, notes] = await prisma.$transaction([
+      prisma.personNote.count({ where: whereClause }),
+      prisma.personNote.findMany({
+        where: whereClause,
+        orderBy,
+        skip: offset,
+        take: PAGE_SIZE,
+        select: {
+          id: true,
+          content: true,
+          author: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          createdAt: true,
+          deletedAt: true,
+        },
+      }),
+    ]);
+
+    const totalPages = Math.ceil(totalRows / PAGE_SIZE);
+    return { notes, totalPages, totalRows };
+  } catch (error) {
+    console.error("Error fetching person notes.", error);
+    throw new Error("Error fetching person notes.");
+  }
+};
+
+export const fetchPersonNotes = RequirePermission(AppPermissions.PERSONS_READ)(
+  _fetchPersonNotes,
+);

--- a/app/lib/form-state-types.ts
+++ b/app/lib/form-state-types.ts
@@ -115,3 +115,20 @@ export interface HouseholdProfileFormState {
     animalExperience?: string[];
   };
 }
+
+export type PartnerFormState = {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    name?: string[];
+    type?: string[];
+    email?: string[];
+    phone?: string[];
+    website?: string[];
+    address?: string[];
+    city?: string[];
+    state?: string[];
+    zipCode?: string[];
+    notes?: string[];
+  };
+};

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -377,3 +377,129 @@ export type HouseholdProfilePayload = Prisma.HouseholdProfileGetPayload<{
     animalExperience: true;
   };
 }>;
+
+export type PartnersDirectoryPayload = Prisma.PartnerGetPayload<{
+  select: {
+    id: true;
+    name: true;
+    type: true;
+    email: true;
+    phone: true;
+    website: true;
+    city: true;
+    state: true;
+    isActive: true;
+    _count: {
+      select: {
+        contacts: true;
+      };
+    };
+  };
+}>;
+
+export type PartnerFormPayload = Prisma.PartnerGetPayload<{
+  select: {
+    id: true;
+    name: true;
+    type: true;
+    email: true;
+    phone: true;
+    website: true;
+    address: true;
+    city: true;
+    state: true;
+    zipCode: true;
+    isActive: true;
+    notes: true;
+  };
+}>;
+
+export type PartnerSectionCardPayload = Prisma.PartnerGetPayload<{
+  select: {
+    id: true;
+    name: true;
+    type: true;
+    email: true;
+    phone: true;
+    website: true;
+    address: true;
+    city: true;
+    state: true;
+    zipCode: true;
+    isActive: true;
+    notes: true;
+    contacts: {
+      where: { isPrimary: true; isActive: true };
+      take: 1;
+      select: {
+        role: true;
+        person: {
+          select: { id: true; name: true; email: true; phone: true };
+        };
+      };
+    };
+    _count: {
+      select: {
+        contacts: true;
+        transferredInAnimals: true;
+        transferredOutAnimals: true;
+        partnerNotes: true;
+      };
+    };
+  };
+}>;
+
+export type PartnerContactsPayload = Prisma.PartnerContactGetPayload<{
+  select: {
+    id: true;
+    role: true;
+    isPrimary: true;
+    isActive: true;
+    person: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        phone: true;
+      };
+    };
+  };
+}>;
+
+export type LinkablePersonPayload = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  isDeactivatedContactHere: boolean;
+};
+
+export type PartnerNotePayload = Prisma.PartnerNoteGetPayload<{
+  select: {
+    id: true;
+    content: true;
+    author: {
+      select: {
+        id: true;
+        name: true;
+      };
+    };
+    createdAt: true;
+    deletedAt: true;
+  };
+}>;
+
+export type PersonNotePayload = Prisma.PersonNoteGetPayload<{
+  select: {
+    id: true;
+    content: true;
+    author: {
+      select: {
+        id: true;
+        name: true;
+      };
+    };
+    createdAt: true;
+    deletedAt: true;
+  };
+}>;

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -343,7 +343,7 @@ export type PersonSectionCardPayload = Prisma.PersonGetPayload<{
         reclaimedAnimalsAsOwner: true;
         tasksAssigned: true;
         tasksCreated: true;
-        notesAuthored: true;
+        animalNotesAuthored: true;
         processedIntakes: true;
         processedOutcomes: true;
         Assessment: true;

--- a/app/lib/zod-schemas/animal.schemas.ts
+++ b/app/lib/zod-schemas/animal.schemas.ts
@@ -75,13 +75,13 @@ export const AnimalFormSchema = z
     animalName: z.string().min(1, {
       error: "Animal name is required.",
     }),
-    species: z.cuid({
+    species: z.cuid2({
       error: "A valid species ID is required.",
     }),
-    breed: z.cuid({
+    breed: z.cuid2({
       error: "A valid primary breed ID is required.",
     }),
-    primaryColor: z.cuid({
+    primaryColor: z.cuid2({
       error: "A valid primary color ID is required.",
     }),
     sex: z.enum(Sex, {
@@ -131,7 +131,7 @@ export const AnimalFormSchema = z
     intakeType: z.enum(IntakeType).optional(),
     intakeDate: z.coerce.date().optional(),
     notes: z.string().optional(),
-    sourcePartnerId: z.cuid().optional().or(z.literal("")),
+    sourcePartnerId: z.cuid2().optional().or(z.literal("")),
     foundAddress: z.string().optional(),
     foundCity: z.string().optional(),
     foundState: z.string().optional(),
@@ -200,7 +200,7 @@ export const TaskFormSchema = z
     priority: z.enum(TaskPriority).optional(),
     dueDate: z.coerce.date().optional(),
     assigneeId: z
-      .cuid({
+      .cuid2({
         error: "Valid assignee ID is required.",
       })
       .optional(),

--- a/app/lib/zod-schemas/common.schemas.ts
+++ b/app/lib/zod-schemas/common.schemas.ts
@@ -5,7 +5,7 @@ export const searchQuerySchema = z.string().trim().max(100, {
 });
 
 // Helper for CUID validation
-export const cuidSchema = z.cuid({
+export const cuidSchema = z.cuid2({
   error: "Invalid ID format. Expected a CUID.",
 });
 

--- a/app/lib/zod-schemas/intake.schema.ts
+++ b/app/lib/zod-schemas/intake.schema.ts
@@ -1,6 +1,5 @@
 import { AnimalHealthStatus, IntakeType } from "@prisma/client";
-// import z from "zod";
-import * as z from "zod"; 
+import { z } from "zod";
 
 export const ReIntakeFormSchema = z
   .object({

--- a/app/lib/zod-schemas/partners-directory.schemas.ts
+++ b/app/lib/zod-schemas/partners-directory.schemas.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+import { PartnerType } from "@prisma/client";
+import {
+  currentPageSchema,
+  pageSizeSchema,
+  searchQuerySchema,
+} from "./common.schemas";
+import { US_STATES } from "@/app/lib/constants/us-states";
+
+export const PeopleDirectoryParamsSchema = z.object({
+  query: searchQuerySchema,
+  currentPage: currentPageSchema,
+  sort: z.string().optional(),
+  pageSize: pageSizeSchema,
+  account: z.string().optional(),
+});
+
+export const PartnersDirectoryParamsSchema = z.object({
+  query: searchQuerySchema,
+  currentPage: currentPageSchema,
+  sort: z.string().optional(),
+  pageSize: pageSizeSchema,
+  type: z.string().optional(),
+  status: z.string().optional(),
+});
+
+const stateCodes = US_STATES.map((state) => state.code) as [
+  string,
+  ...string[],
+];
+
+export const PersonFormSchema = z.object({
+  name: z.string().min(1, {
+    error: "Name is required.",
+  }),
+  email: z
+    .email({ error: "Please enter a valid email address." })
+    .optional()
+    .or(z.literal("")),
+  phone: z.string().optional(),
+  address: z.string().optional(),
+  city: z.string().optional(),
+  state: z
+    .string()
+    .optional()
+    .refine((val) => !val || stateCodes.includes(val), {
+      error: "Please select a valid US state.",
+    }),
+  zipCode: z.string().optional(),
+});
+
+export const PartnerFormSchema = z.object({
+  name: z.string().min(1, { error: "Name is required." }),
+  type: z.enum(PartnerType, {
+    error: (issue) =>
+      issue.input === undefined ? "Please select a partner type." : undefined,
+  }),
+  email: z
+    .email({ error: "Please enter a valid email address." })
+    .optional()
+    .or(z.literal("")),
+  phone: z.string().optional(),
+  website: z
+    .url({ error: "Please enter a valid URL (including https://)." })
+    .optional()
+    .or(z.literal("")),
+  address: z.string().optional(),
+  city: z.string().optional(),
+  state: z
+    .string()
+    .optional()
+    .refine((val) => !val || stateCodes.includes(val), {
+      error: "Please select a valid US state.",
+    }),
+  zipCode: z.string().optional(),
+  isActive: z.boolean().optional(),
+  notes: z.string().optional(),
+});
+
+export const PartnerContactFormSchema = z.object({
+  personId: z.cuid2({ error: "Please select a person." }),
+  role: z.string().optional(),
+  isPrimary: z.boolean().optional(),
+  isActive: z.boolean().optional(),
+});
+
+export const PartnerNotesParamsSchema = z.object({
+  currentPage: currentPageSchema,
+  sort: z.string().optional(),
+  status: z.string().optional(),
+});
+
+export const PartnerNoteFormSchema = z.object({
+  content: z.string().min(1, { error: "Content cannot be empty." }),
+});

--- a/app/lib/zod-schemas/people-directory.schemas.ts
+++ b/app/lib/zod-schemas/people-directory.schemas.ts
@@ -38,3 +38,13 @@ export const PersonFormSchema = z.object({
     }),
   zipCode: z.string().optional(),
 });
+
+export const PersonNotesParamsSchema = z.object({
+  currentPage: currentPageSchema,
+  sort: z.string().optional(),
+  status: z.string().optional(),
+});
+
+export const PersonNoteFormSchema = z.object({
+  content: z.string().min(1, { error: "Content cannot be empty." }),
+});

--- a/components/dashboard/animals/notes/notes.tsx
+++ b/components/dashboard/animals/notes/notes.tsx
@@ -35,7 +35,6 @@ import { NoteActions } from "./note-actions";
 import { SimplePagination } from "../../../simple-pagination";
 import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
 import { ServerSideSort } from "@/components/table-common/server-side-sort";
-import { ServerSideSwitch } from "@/components/table-common/server-side-switch";
 
 export const noteCategoryColors: Record<NoteCategory, string> = {
   [NoteCategory.BEHAVIORAL]: "bg-blue-100 text-blue-800 border-blue-200",
@@ -46,6 +45,11 @@ export const noteCategoryColors: Record<NoteCategory, string> = {
     "bg-purple-100 text-purple-800 border-purple-200",
   [NoteCategory.FOSTER_UPDATE]: "bg-green-100 text-green-800 border-green-200",
 };
+
+const noteStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "deleted", label: "Deleted" },
+];
 
 interface Props {
   notes: NotePayload[];
@@ -106,6 +110,14 @@ const AnimalNotes = ({ notes, totalPages, animalId, canManage }: Props) => {
             </div>
 
             <div className="flex items-center gap-2">
+              <ServerSideFacetedFilter
+                title="Status"
+                paramKey="status"
+                options={noteStatusOptions}
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
               <ServerSideSort
                 paramKey="sort"
                 placeholder="Select order"
@@ -115,8 +127,6 @@ const AnimalNotes = ({ notes, totalPages, animalId, canManage }: Props) => {
                 ]}
               />
             </div>
-
-            <ServerSideSwitch paramKey="showDeleted" label="Show Deleted" />
           </div>
         </CardHeader>
 
@@ -128,9 +138,11 @@ const AnimalNotes = ({ notes, totalPages, animalId, canManage }: Props) => {
                   key={note.id}
                   className="border rounded-lg p-4 relative group"
                 >
-                  <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <NoteActions note={note} animalId={animalId} />
-                  </div>
+                  {canManage && (
+                    <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <NoteActions note={note} animalId={animalId} />
+                    </div>
+                  )}
 
                   <div className="flex items-start gap-4">
                     <div className="flex-1">

--- a/components/dashboard/nav/icon-map.ts
+++ b/components/dashboard/nav/icon-map.ts
@@ -19,6 +19,7 @@ import {
   IconFileText,
   IconChecks,
   IconCheckbox,
+  IconBuildingStore
 } from "@tabler/icons-react";
 import type { TablerIcon } from "@tabler/icons-react";
 import type { IconName } from "./nav-links.config";
@@ -44,6 +45,7 @@ export const iconMap: Record<IconName, TablerIcon> = {
   IconFileText,
   IconChecks,
   IconCheckbox,
+  IconBuildingStore,
 };
 
 // Helper function to get icon component from string name

--- a/components/dashboard/nav/nav-links.config.ts
+++ b/components/dashboard/nav/nav-links.config.ts
@@ -25,6 +25,7 @@ export type IconName =
   | "IconFileText"
   | "IconChecks"
   | "IconCheckbox"
+  | "IconBuildingStore"
 
 export interface NavItem {
   title: string;
@@ -71,6 +72,12 @@ export const navMainItems: readonly NavItem[] = [
     url: "/dashboard/people-directory",
     icon: "IconUsersGroup",
     permission: AppPermissions.PERSONS_READ,
+  },
+  {
+    title: "Partner Directory",
+    url: "/dashboard/partners-directory",
+    icon: "IconBuildingStore",
+    permission: AppPermissions.PARTNERS_READ,
   },
   {
     title: "My Applications",

--- a/components/dashboard/outcomes/table/outcome-table-columns.tsx
+++ b/components/dashboard/outcomes/table/outcome-table-columns.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -48,7 +49,16 @@ export const getColumns = ({
     ),
     cell: ({ row }) => {
       const { animal } = row.original;
-      return <div className="font-medium">{animal.name}</div>;
+      return (
+        <div className="font-medium">
+          <Link
+            href={`/dashboard/animals/${animal.id}`}
+            className="hover:underline"
+          >
+            {animal.name}
+          </Link>
+        </div>
+      );
     },
   },
   {

--- a/components/dashboard/partners-directory/animal-history/partner-animal-history.tsx
+++ b/components/dashboard/partners-directory/animal-history/partner-animal-history.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import React, { useState } from "react";
+import { clsx } from "clsx";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import { formatDateOrNA, formatTimeAgo } from "@/app/lib/utils/date-utils";
+import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  PartnerAnimalHistoryEntry,
+  PartnerTransferDirection,
+} from "@/app/lib/data/partners-directory/partner-animal-history.data";
+
+export const transferDirectionColors: Record<PartnerTransferDirection, string> =
+  {
+    TRANSFER_IN: "bg-green-100 text-green-800 border-green-200",
+    TRANSFER_OUT: "bg-orange-100 text-orange-800 border-orange-200",
+  };
+
+const transferDirectionLabels: Record<PartnerTransferDirection, string> = {
+  TRANSFER_IN: "Received From",
+  TRANSFER_OUT: "Transferred To",
+};
+
+const INITIAL_DISPLAY_COUNT = 10;
+
+interface Props {
+  history: PartnerAnimalHistoryEntry[];
+}
+
+const PartnerAnimalHistory = ({ history }: Props) => {
+  const [showAll, setShowAll] = useState(false);
+
+  const visibleHistory = showAll
+    ? history
+    : history.slice(0, INITIAL_DISPLAY_COUNT);
+
+  const hasMore = history.length > INITIAL_DISPLAY_COUNT;
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Animal History</CardTitle>
+        <CardDescription>
+          Animals received from or transferred to this partner.
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent>
+        <div className="space-y-4">
+          {visibleHistory.length > 0 ? (
+            visibleHistory.map((entry, index) => {
+              const firstImage = entry.animal.animalImages?.[0]?.url;
+              const subtype =
+                entry.direction === "TRANSFER_IN"
+                  ? entry.intakeType
+                  : entry.outcomeType;
+
+              return (
+                <div
+                  key={`${entry.direction}-${entry.animal.id}-${index}`}
+                  className="border rounded-lg p-4 relative"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="relative flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-secondary">
+                      {firstImage ? (
+                        <Image
+                          src={firstImage}
+                          alt={`Photo of ${entry.animal.name}`}
+                          fill
+                          sizes="64px"
+                          className="object-cover"
+                        />
+                      ) : (
+                        <span className="text-2xl">🐾</span>
+                      )}
+                    </div>
+
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3 flex-wrap">
+                        <Badge
+                          variant="outline"
+                          className={clsx(
+                            "font-semibold",
+                            transferDirectionColors[entry.direction],
+                          )}
+                        >
+                          {transferDirectionLabels[entry.direction]}
+                        </Badge>
+                        <Link
+                          href={`/dashboard/animals/${entry.animal.id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {entry.animal.name}
+                        </Link>
+                        <span className="text-sm text-muted-foreground">
+                          {entry.animal.species.name}
+                        </span>
+                        <Badge variant="secondary">
+                          {formatSingleEnumOption(entry.animal.listingStatus)}
+                        </Badge>
+                      </div>
+
+                      {subtype && (
+                        <p className="text-sm text-muted-foreground mt-2">
+                          Type:{" "}
+                          <span className="font-medium text-foreground">
+                            {formatSingleEnumOption(subtype)}
+                          </span>
+                        </p>
+                      )}
+
+                      <div className="text-xs text-gray-500 mt-3">
+                        {entry.date ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="underline decoration-dotted cursor-help">
+                                {formatTimeAgo(entry.date)}
+                              </span>
+                            </TooltipTrigger>
+
+                            <TooltipContent>
+                              {formatDateOrNA(entry.date)}
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span>—</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div className="text-center text-gray-500 py-12 border-2 border-dashed rounded-lg">
+              <p className="font-semibold text-lg">No Animal History Found</p>
+
+              <p className="text-sm mt-1">
+                No animals have been received from or transferred to this
+                partner.
+              </p>
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      {hasMore && (
+        <CardFooter className="justify-center">
+          <Button variant="outline" onClick={() => setShowAll((prev) => !prev)}>
+            {showAll
+              ? "Show Less"
+              : `Show ${history.length - INITIAL_DISPLAY_COUNT} More`}
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default PartnerAnimalHistory;

--- a/components/dashboard/partners-directory/contacts/contact-row-actions.tsx
+++ b/components/dashboard/partners-directory/contacts/contact-row-actions.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PartnerContactsPayload, LinkablePersonPayload } from "@/app/lib/types";
+import { PartnerContactForm } from "./partner-contact-form";
+import {
+  setPrimaryContact,
+  setContactActive,
+} from "@/app/lib/actions/partner-contact.actions";
+import { toast } from "sonner";
+
+interface ContactActionsProps {
+  contact: PartnerContactsPayload;
+  people: LinkablePersonPayload[];
+  partnerId: string;
+}
+
+export function ContactActions({
+  contact,
+  people,
+  partnerId,
+}: ContactActionsProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSetPrimary = () => {
+    startTransition(() => {
+      setPrimaryContact(contact.id, partnerId).then((data) => {
+        if (!data.success) {
+          toast.error(data.message);
+          return;
+        }
+        // Offer undo only when a previous primary was demoted.
+        if (data.previousPrimary) {
+          const prev = data.previousPrimary;
+          toast.success(data.message, {
+            action: {
+              label: "Undo",
+              onClick: () => onUndoPrimary(prev.id, prev.name),
+            },
+          });
+        } else {
+          toast.success(data.message);
+        }
+      });
+    });
+  };
+
+  const onUndoPrimary = (previousId: string, previousName: string) => {
+    startTransition(() => {
+      setPrimaryContact(previousId, partnerId).then((data) => {
+        if (data.success) {
+          toast.success(`Reverted primary to ${previousName}.`);
+        } else {
+          toast.error("Couldn't undo.");
+        }
+      });
+    });
+  };
+
+  const onToggleActive = () => {
+    startTransition(() => {
+      setContactActive(contact.id, partnerId, !contact.isActive).then(
+        (data) => {
+          if (data.success) {
+            toast.success(data.message);
+          } else {
+            toast.error(data.message);
+          }
+        },
+      );
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+
+          {!contact.isPrimary && contact.isActive && (
+            <DropdownMenuItem onClick={onSetPrimary} disabled={isPending}>
+              Set as primary
+            </DropdownMenuItem>
+          )}
+
+          {contact.isActive ? (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onToggleActive}
+              disabled={isPending}
+            >
+              Deactivate
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem onClick={onToggleActive} disabled={isPending}>
+              Reactivate
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Edit Contact</DialogTitle>
+          <DialogDescription>
+            Update this contact&apos;s role, primary status, or active status.
+          </DialogDescription>
+        </DialogHeader>
+        <PartnerContactForm
+          partnerId={partnerId}
+          people={people}
+          contact={contact}
+          onFormSubmit={() => setIsDialogOpen(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dashboard/partners-directory/contacts/partner-contact-form.tsx
+++ b/components/dashboard/partners-directory/contacts/partner-contact-form.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { startTransition, useActionState, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  addPartnerContact,
+  updatePartnerContact,
+  type PartnerContactFormState,
+} from "@/app/lib/actions/partner-contact.actions";
+import { PartnerContactFormSchema } from "@/app/lib/zod-schemas/partners-directory.schemas";
+import { PartnerContactsPayload, LinkablePersonPayload } from "@/app/lib/types";
+import { PersonPicker, type SelectedPerson } from "./person-picker";
+
+const INITIAL_FORM_STATE: PartnerContactFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type PartnerContactFormValues = z.infer<typeof PartnerContactFormSchema>;
+
+interface Props {
+  partnerId: string;
+  people: LinkablePersonPayload[]; // preloaded list for the picker
+  onFormSubmit: () => void; // close the dialog on success
+  contact?: PartnerContactsPayload; // present = edit mode
+}
+
+export const PartnerContactForm = ({
+  partnerId,
+  people,
+  onFormSubmit,
+  contact,
+}: Props) => {
+  const isEditMode = !!contact;
+
+  // In edit mode the person is locked; seed the picker's display value.
+  const [selectedPerson, setSelectedPerson] = useState<SelectedPerson | null>(
+    contact
+      ? {
+          id: contact.person.id,
+          name: contact.person.name,
+          isDeactivatedContactHere: false,
+        }
+      : null,
+  );
+
+  const action = isEditMode
+    ? updatePartnerContact.bind(null, contact.id, partnerId)
+    : addPartnerContact.bind(null, partnerId);
+
+  const [state, formAction, isPending] = useActionState<
+    PartnerContactFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<PartnerContactFormValues>({
+    resolver: zodResolver(PartnerContactFormSchema),
+    defaultValues: contact
+      ? {
+          personId: contact.person.id,
+          role: contact.role || "",
+          isPrimary: contact.isPrimary,
+          isActive: contact.isActive,
+        }
+      : {
+          personId: "",
+          role: "",
+          isPrimary: false,
+          isActive: true,
+        },
+  });
+
+  useEffect(() => {
+    if (!state.message) {
+      return;
+    }
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors && Object.keys(state.errors).length > 0) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof PartnerContactFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  // Keep the RHF personId field in sync with the picker's selection.
+  const handlePersonChange = (person: SelectedPerson | null) => {
+    setSelectedPerson(person);
+    form.setValue("personId", person?.id ?? "", {
+      shouldValidate: true,
+      shouldDirty: true,
+    });
+  };
+
+  const onSubmit = (data: PartnerContactFormValues) => {
+    const formData = new FormData();
+    formData.append("personId", data.personId);
+    if (data.role) {
+      formData.append("role", data.role);
+    }
+    // Checkboxes: append only when true (action reads "present = true").
+    if (data.isPrimary) {
+      formData.append("isPrimary", "on");
+    }
+    if (data.isActive) {
+      formData.append("isActive", "on");
+    }
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {/* Person picker (locked in edit mode) */}
+        <FormField
+          control={form.control}
+          name="personId"
+          render={() => (
+            <FormItem>
+              <FormLabel>Person</FormLabel>
+              <PersonPicker
+                people={people}
+                value={selectedPerson}
+                onChange={handlePersonChange}
+                disabled={isEditMode}
+              />
+              {isEditMode ? (
+                <FormDescription>
+                  The linked person can&apos;t be changed. Remove this contact
+                  and add another to link a different person.
+                </FormDescription>
+              ) : selectedPerson?.isDeactivatedContactHere ? (
+                <FormDescription>
+                  This person was previously a contact here. Adding them will
+                  reactivate that link.
+                </FormDescription>
+              ) : null}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Role */}
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Role</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g., Intake Coordinator" {...field} />
+              </FormControl>
+              <FormDescription>
+                Their role at this partner (optional).
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Primary */}
+        <FormField
+          control={form.control}
+          name="isPrimary"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+              <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+              <div className="space-y-1 leading-none">
+                <FormLabel>Primary contact</FormLabel>
+                <FormDescription>
+                  The main point of contact. Setting this unsets any existing
+                  primary.
+                </FormDescription>
+              </div>
+            </FormItem>
+          )}
+        />
+
+        {/* Active */}
+        <FormField
+          control={form.control}
+          name="isActive"
+          render={({ field }) => (
+            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+              <FormControl>
+                <Checkbox
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+              <div className="space-y-1 leading-none">
+                <FormLabel>Active</FormLabel>
+                <FormDescription>
+                  Uncheck to keep the link for history without it being a
+                  current contact.
+                </FormDescription>
+              </div>
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {isEditMode ? "Updating..." : "Adding..."}
+              </>
+            ) : isEditMode ? (
+              "Update Contact"
+            ) : (
+              "Add Contact"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/partners-directory/contacts/partner-contacts.tsx
+++ b/components/dashboard/partners-directory/contacts/partner-contacts.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { clsx } from "clsx";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Mail, Phone, Star } from "lucide-react";
+import Link from "next/link";
+import { PartnerContactsPayload, LinkablePersonPayload } from "@/app/lib/types";
+import { PartnerContactForm } from "./partner-contact-form";
+import { ContactActions } from "./contact-row-actions";
+
+const INITIAL_DISPLAY_COUNT = 10;
+
+interface Props {
+  contacts: PartnerContactsPayload[];
+  people: LinkablePersonPayload[];
+  partnerId: string;
+  canManage: boolean;
+}
+
+const PartnerContacts = ({
+  contacts,
+  people,
+  partnerId,
+  canManage,
+}: Props) => {
+  const [showAll, setShowAll] = useState(false);
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  const visibleContacts = showAll
+    ? contacts
+    : contacts.slice(0, INITIAL_DISPLAY_COUNT);
+
+  const hasMore = contacts.length > INITIAL_DISPLAY_COUNT;
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Contacts</CardTitle>
+
+        <CardDescription>
+          People linked to this partner as points of contact.
+        </CardDescription>
+
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button
+                variant={canManage ? "default" : "outline"}
+                size="sm"
+                className="disabled:pointer-events-auto disabled:cursor-not-allowed"
+                disabled={!canManage}
+              >
+                Add Contact
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[600px]">
+              <DialogHeader>
+                <DialogTitle>Add Contact</DialogTitle>
+                <DialogDescription>
+                  Link a person to this partner as a point of contact.
+                </DialogDescription>
+              </DialogHeader>
+              <PartnerContactForm
+                partnerId={partnerId}
+                people={people}
+                onFormSubmit={() => setIsAddDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+      </CardHeader>
+
+      <CardContent>
+        <div className="space-y-4">
+          {visibleContacts.length > 0 ? (
+            visibleContacts.map((contact) => (
+              <div
+                key={contact.id}
+                className={clsx(
+                  "border rounded-lg p-4 relative group",
+                  !contact.isActive && "opacity-60",
+                )}
+              >
+                {canManage && (
+                  <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <ContactActions
+                      contact={contact}
+                      people={people}
+                      partnerId={partnerId}
+                    />
+                  </div>
+                )}
+
+                <div className="flex items-start gap-4">
+                  <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg border bg-secondary text-2xl">
+                    👤
+                  </div>
+
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <Link
+                        href={`/dashboard/people-directory/${contact.person.id}`}
+                        className="font-medium hover:underline"
+                      >
+                        {contact.person.name}
+                      </Link>
+                      {contact.isPrimary && (
+                        <Badge
+                          variant="outline"
+                          className="font-semibold bg-amber-100 text-amber-800 border-amber-200"
+                        >
+                          <Star className="mr-1 h-3 w-3" />
+                          Primary
+                        </Badge>
+                      )}
+                      {!contact.isActive && (
+                        <Badge variant="secondary">Inactive</Badge>
+                      )}
+                    </div>
+
+                    {contact.role && (
+                      <p className="text-sm text-muted-foreground mt-2">
+                        {contact.role}
+                      </p>
+                    )}
+
+                    <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
+                      {contact.person.email && (
+                        <span className="flex items-center gap-1 break-all">
+                          <Mail className="h-3 w-3" />
+                          {contact.person.email}
+                        </span>
+                      )}
+                      {contact.person.phone && (
+                        <span className="flex items-center gap-1">
+                          <Phone className="h-3 w-3" />
+                          {contact.person.phone}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-12 border-2 border-dashed rounded-lg">
+              <p className="font-semibold text-lg">No Contacts Found</p>
+
+              <p className="text-sm mt-1">
+                This partner has no linked contacts yet.
+              </p>
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      {hasMore && (
+        <CardFooter className="justify-center">
+          <Button variant="outline" onClick={() => setShowAll((prev) => !prev)}>
+            {showAll
+              ? "Show Less"
+              : `Show ${contacts.length - INITIAL_DISPLAY_COUNT} More`}
+          </Button>
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default PartnerContacts;

--- a/components/dashboard/partners-directory/contacts/person-picker.tsx
+++ b/components/dashboard/partners-directory/contacts/person-picker.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { LinkablePersonPayload } from "@/app/lib/types";
+
+export type SelectedPerson = {
+  id: string;
+  name: string;
+  isDeactivatedContactHere: boolean;
+};
+
+interface Props {
+  people: LinkablePersonPayload[];
+  value: SelectedPerson | null;
+  onChange: (person: SelectedPerson | null) => void;
+  disabled?: boolean;
+}
+
+export const PersonPicker = ({ people, value, onChange, disabled }: Props) => {
+  const [open, setOpen] = useState(false);
+
+  const handleSelect = (person: LinkablePersonPayload) => {
+    onChange({
+      id: person.id,
+      name: person.name,
+      isDeactivatedContactHere: person.isDeactivatedContactHere,
+    });
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            "w-full justify-between font-normal",
+            !value && "text-muted-foreground",
+          )}
+        >
+          {value ? value.name : "Search for a person..."}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Type a name or email..." />
+          <CommandList>
+            <CommandEmpty>No people found.</CommandEmpty>
+            <CommandGroup>
+              {people.map((person) => (
+                <CommandItem
+                  key={person.id}
+                  value={`${person.name} ${person.email ?? ""}`}
+                  onSelect={() => handleSelect(person)}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value?.id === person.id ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate">{person.name}</p>
+                      {person.email ? (
+                        <p className="truncate text-xs text-muted-foreground">
+                          {person.email}
+                        </p>
+                      ) : null}
+                    </div>
+                    {person.isDeactivatedContactHere ? (
+                      <Badge
+                        variant="outline"
+                        className="flex-shrink-0 bg-gray-100 text-gray-700 border-gray-300 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700"
+                      >
+                        Deactivated here
+                      </Badge>
+                    ) : null}
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/components/dashboard/partners-directory/notes/partner-note-form.tsx
+++ b/components/dashboard/partners-directory/notes/partner-note-form.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  createPartnerNote,
+  updatePartnerNote,
+  type PartnerNoteFormState,
+} from "@/app/lib/actions/partner-note.actions";
+import { PartnerNoteFormSchema } from "@/app/lib/zod-schemas/partners-directory.schemas";
+import { PartnerNotePayload } from "@/app/lib/types";
+
+const INITIAL_FORM_STATE: PartnerNoteFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type PartnerNoteFormValues = z.infer<typeof PartnerNoteFormSchema>;
+
+interface Props {
+  partnerId: string;
+  onFormSubmit: () => void; // close the dialog on success
+  note?: PartnerNotePayload;
+}
+
+export const PartnerNoteForm = ({ partnerId, onFormSubmit, note }: Props) => {
+  const action = note
+    ? updatePartnerNote.bind(null, note.id, partnerId)
+    : createPartnerNote.bind(null, partnerId);
+
+  const [state, formAction, isPending] = useActionState<
+    PartnerNoteFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<PartnerNoteFormValues>({
+    resolver: zodResolver(PartnerNoteFormSchema),
+    defaultValues: note
+      ? { content: note.content }
+      : { content: "" },
+  });
+
+  useEffect(() => {
+    if (!state.message) {
+      return;
+    }
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors && Object.keys(state.errors).length > 0) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof PartnerNoteFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: PartnerNoteFormValues) => {
+    const formData = new FormData();
+    formData.append("content", data.content);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Content</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Provide a detailed description of the note..."
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {note ? "Updating..." : "Creating..."}
+              </>
+            ) : note ? (
+              "Update Note"
+            ) : (
+              "Create Note"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/partners-directory/notes/partner-notes.tsx
+++ b/components/dashboard/partners-directory/notes/partner-notes.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import { clsx } from "clsx";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PartnerNotePayload } from "@/app/lib/types";
+import { formatDateOrNA, formatTimeAgo } from "@/app/lib/utils/date-utils";
+import { PartnerNoteForm } from "./partner-note-form";
+import { SimplePagination } from "../../../simple-pagination";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ServerSideSort } from "@/components/table-common/server-side-sort";
+import { PartnerNoteActions } from "@/app/lib/actions/partner-note-actions";
+
+const noteStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "deleted", label: "Deleted" },
+];
+
+interface Props {
+  notes: PartnerNotePayload[];
+  totalPages: number;
+  totalRows: number;
+  partnerId: string;
+  canManage: boolean;
+}
+
+const PartnerNotes = ({
+  notes,
+  totalPages,
+  partnerId,
+  canManage,
+}: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Partner Notes</CardTitle>
+
+        <CardDescription>
+          Keep track of important notes about this partner.
+        </CardDescription>
+
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button
+                variant={canManage ? "default" : "outline"}
+                size="sm"
+                className="disabled:pointer-events-auto disabled:cursor-not-allowed"
+                disabled={!canManage}
+              >
+                Add Note
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[600px]">
+              <DialogHeader>
+                <DialogTitle>Add Note</DialogTitle>
+                <DialogDescription>
+                  Add a new note for this partner. Click create note when
+                  you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <PartnerNoteForm
+                partnerId={partnerId}
+                onFormSubmit={() => setIsAddDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+
+        {/* Filter and Sort Controls */}
+        <div className="mt-4 flex flex-row flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <ServerSideFacetedFilter
+              title="Status"
+              paramKey="status"
+              options={noteStatusOptions}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <ServerSideSort
+              paramKey="sort"
+              placeholder="Select order"
+              options={[
+                { label: "Newest First", value: "createdAt.desc" },
+                { label: "Oldest First", value: "createdAt.asc" },
+              ]}
+            />
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <div className="space-y-4">
+          {notes.length > 0 ? (
+            notes.map((note) => (
+              <div
+                key={note.id}
+                className={clsx(
+                  "border rounded-lg p-4 relative group",
+                  note.deletedAt && "opacity-60",
+                )}
+              >
+                {canManage && (
+                  <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <PartnerNoteActions note={note} partnerId={partnerId} />
+                  </div>
+                )}
+
+                <div className="flex items-start gap-4">
+                  <div className="flex-1">
+                    {note.deletedAt && (
+                      <div className="mb-2">
+                        <Badge variant="destructive">Deleted</Badge>
+                      </div>
+                    )}
+
+                    <p className="text-sm text-gray-700 whitespace-pre-wrap">
+                      {note.content}
+                    </p>
+
+                    <div className="text-xs text-gray-500 mt-3">
+                      <span>{note.author?.name ?? "Unknown User"}</span>{" "}
+                      &middot;{" "}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="underline decoration-dotted cursor-help">
+                            {formatTimeAgo(note.createdAt)}
+                          </span>
+                        </TooltipTrigger>
+
+                        <TooltipContent>
+                          {formatDateOrNA(note.createdAt)}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-12 border-2 border-dashed rounded-lg">
+              <p className="font-semibold text-lg">No Notes Found</p>
+
+              <p className="text-sm mt-1">
+                Try adjusting your filters or creating a new note.
+              </p>
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      <CardFooter>
+        <SimplePagination totalPages={totalPages} />
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default PartnerNotes;

--- a/components/dashboard/partners-directory/partner-form.tsx
+++ b/components/dashboard/partners-directory/partner-form.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+import {
+  createPartner,
+  updatePartner,
+} from "@/app/lib/actions/partner.actions";
+import { startTransition, useActionState, useEffect } from "react";
+import {
+  INITIAL_FORM_STATE,
+  PartnerFormState,
+} from "@/app/lib/form-state-types";
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { PartnerFormSchema } from "@/app/lib/zod-schemas/partners-directory.schemas";
+import { PartnerTypesOptions } from "@/components/dashboard/partners-directory/table/partners-directory-options";
+import { US_STATES } from "@/app/lib/constants/us-states";
+import Link from "next/link";
+import { PartnerFormPayload } from "@/app/lib/types";
+import { PartnerType } from "@prisma/client";
+
+type PartnerFormValues = z.infer<typeof PartnerFormSchema>;
+
+interface PartnerFormProps {
+  partner?: PartnerFormPayload;
+  cancelHref?: string;
+  returnTo?: string;
+}
+
+const PartnerForm = ({ partner, cancelHref, returnTo }: PartnerFormProps) => {
+  const isEditMode = !!partner;
+
+  const resolvedCancelHref =
+    cancelHref ??
+    returnTo ??
+    (isEditMode
+      ? `/dashboard/partners-directory/${partner.id}`
+      : "/dashboard/partners-directory");
+
+  const action = isEditMode
+    ? updatePartner.bind(null, partner.id)
+    : createPartner;
+
+  const [state, formAction, isPending] = useActionState<
+    PartnerFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm({
+    resolver: standardSchemaResolver(PartnerFormSchema),
+    defaultValues: isEditMode
+      ? {
+          name: partner.name,
+          type: partner.type,
+          email: partner.email || "",
+          phone: partner.phone || "",
+          website: partner.website || "",
+          address: partner.address || "",
+          city: partner.city || "",
+          state: partner.state || "",
+          zipCode: partner.zipCode || "",
+          isActive: partner.isActive,
+          notes: partner.notes || "",
+        }
+      : {
+          name: "",
+          type: "" as PartnerType,
+          email: "",
+          phone: "",
+          website: "",
+          address: "",
+          city: "",
+          state: "",
+          zipCode: "",
+          isActive: true,
+          notes: "",
+        },
+  });
+
+  useEffect(() => {
+    if (state.message) {
+      toast.error(state.message);
+    }
+
+    if (state.errors) {
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof PartnerFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    }
+  }, [state, form]);
+
+  const onSubmit = (data: PartnerFormValues) => {
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(data)) {
+      if (key === "isActive") continue;
+      if (value != null && value !== "") {
+        formData.append(key, String(value));
+      }
+    }
+    if (data.isActive) {
+      formData.append("isActive", "on");
+    }
+    if (returnTo) {
+      formData.append("returnTo", returnTo);
+    }
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <Card className="w-full max-w-3xl mx-auto">
+          <CardHeader>
+            <CardTitle>{isEditMode ? "Edit Partner" : "New Partner"}</CardTitle>
+            <CardDescription>
+              {isEditMode
+                ? `Editing the record for ${partner.name}.`
+                : "Register a new partner organization — a shelter, rescue, vet clinic, or agency."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-10">
+            <div className="space-y-6">
+              <h3 className="font-semibold border-b pb-2">
+                Organization Details
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-6 gap-x-4 gap-y-8">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem className="col-span-4">
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g., Westchester Humane Society"
+                          {...field}
+                          autoComplete="off"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="type"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Type</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Select a type" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {PartnerTypesOptions.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                              {option.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem className="col-span-3">
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="email"
+                          placeholder="e.g., intake@example.org"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem className="col-span-3">
+                      <FormLabel>Phone</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., (555) 123-4567" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="website"
+                  render={({ field }) => (
+                    <FormItem className="col-span-full">
+                      <FormLabel>Website</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g., https://example.org"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field }) => (
+                    <FormItem className="col-span-full">
+                      <FormLabel>Street Address</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., 123 Main St" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="city"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>City</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., Anytown" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="state"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>State</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Select a state" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {US_STATES.map((state) => (
+                            <SelectItem key={state.code} value={state.code}>
+                              {state.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="zipCode"
+                  render={({ field }) => (
+                    <FormItem className="col-span-2">
+                      <FormLabel>Zip Code</FormLabel>
+                      <FormControl>
+                        <Input placeholder="e.g., 12345" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <h3 className="font-semibold border-b pb-2">Status & Notes</h3>
+              <div className="space-y-8">
+                <FormField
+                  control={form.control}
+                  name="isActive"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <div className="space-y-1 leading-none">
+                        <FormLabel>Active partner</FormLabel>
+                        <FormDescription>
+                          Uncheck to retire this partner without deleting it.
+                        </FormDescription>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="notes"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Quick note</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          placeholder="e.g., Transfers weekdays only."
+                          className="resize-none"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormDescription>
+                        A short pinned blurb. Dated note history lives on the
+                        partner&apos;s detail page.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex justify-end space-x-4">
+            <Button
+              asChild
+              variant="outline"
+              type="button"
+              disabled={isPending}
+            >
+              <Link href={resolvedCancelHref}>Cancel</Link>
+            </Button>
+            <Button type="submit" size="lg" disabled={isPending}>
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isPending
+                ? isEditMode
+                  ? "Updating..."
+                  : "Creating..."
+                : isEditMode
+                  ? "Save Changes"
+                  : "Create Partner"}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </Form>
+  );
+};
+
+export default PartnerForm;

--- a/components/dashboard/partners-directory/partner-section-cards.tsx
+++ b/components/dashboard/partners-directory/partner-section-cards.tsx
@@ -1,0 +1,251 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { PartnerSectionCardPayload, IDParamType } from "@/app/lib/types";
+import { fetchSectionCardsPartnerData } from "@/app/lib/data/partners-directory/partners-directory.data";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { PartnerTypesOptions } from "@/components/dashboard/partners-directory/table/partners-directory-options";
+import {
+  Mail,
+  Phone,
+  Globe,
+  MapPin,
+  StickyNote,
+  Users,
+  ArrowDownLeft,
+  ArrowUpRight,
+  FileText,
+  UserStar,
+} from "lucide-react";
+import { hasPermission } from "@/app/lib/auth/hasPermission";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+
+interface Props {
+  params: IDParamType;
+}
+
+const PartnerSectionCards = async ({ params }: Props) => {
+  const { id } = await params;
+
+  const partner: PartnerSectionCardPayload | null =
+    await fetchSectionCardsPartnerData(id);
+
+  if (!partner) {
+    notFound();
+  }
+
+  const canManage = await hasPermission(AppPermissions.PARTNERS_MANAGE);
+
+  const fullAddress = [
+    partner.address,
+    partner.city,
+    partner.state,
+    partner.zipCode,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  const typeMeta = PartnerTypesOptions.find((t) => t.value === partner.type);
+  const primaryContact = partner.contacts[0] ?? null;
+
+  const tiles = [
+    {
+      label: "Contacts",
+      value: partner._count.contacts,
+      icon: Users,
+      color: "text-blue-500",
+    },
+    {
+      label: "Transfers In",
+      value: partner._count.transferredInAnimals,
+      icon: ArrowDownLeft,
+      color: "text-green-600",
+    },
+    {
+      label: "Transfers Out",
+      value: partner._count.transferredOutAnimals,
+      icon: ArrowUpRight,
+      color: "text-orange-500",
+    },
+    {
+      label: "Notes",
+      value: partner._count.partnerNotes,
+      icon: FileText,
+      color: "text-purple-500",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2">
+      {/* Left column */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <CardTitle className="mb-1">{partner.name}</CardTitle>
+              <CardDescription className="flex items-center gap-2">
+                {typeMeta ? (
+                  <Badge variant="outline" className={typeMeta.className}>
+                    <typeMeta.icon className="mr-1 h-3 w-3" />
+                    {typeMeta.label}
+                  </Badge>
+                ) : null}
+              </CardDescription>
+            </div>
+            <CardAction>
+              <span
+                className={cn(
+                  "inline-block",
+                  !canManage && "cursor-not-allowed",
+                )}
+              >
+                <Button
+                  asChild
+                  size="sm"
+                  variant={canManage ? "default" : "outline"}
+                  className={cn(!canManage && "pointer-events-none opacity-50")}
+                >
+                  <Link
+                    href={`/dashboard/partners-directory/${partner.id}/edit`}
+                    aria-disabled={!canManage}
+                    tabIndex={canManage ? undefined : -1}
+                  >
+                    Edit Partner
+                  </Link>
+                </Button>
+              </span>
+            </CardAction>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-5">
+          {/* Status */}
+          <div className="flex items-center gap-2">
+            <Badge variant={partner.isActive ? "default" : "secondary"}>
+              {partner.isActive ? "Active" : "Inactive"}
+            </Badge>
+          </div>
+
+          {/* Contact info */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between border-b pb-2 text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Mail className="h-4 w-4" /> Email
+              </span>
+              <span className="font-medium break-all">
+                {partner.email || "N/A"}
+              </span>
+            </div>
+            <div className="flex items-center justify-between border-b pb-2 text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Phone className="h-4 w-4" /> Phone
+              </span>
+              <span className="font-medium">{partner.phone || "N/A"}</span>
+            </div>
+            <div className="flex items-center justify-between border-b pb-2 text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <Globe className="h-4 w-4" /> Website
+              </span>
+              <span className="font-medium break-all">
+                {partner.website ? (
+                  <Link
+                    href={partner.website}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline"
+                  >
+                    {partner.website}
+                  </Link>
+                ) : (
+                  "N/A"
+                )}
+              </span>
+            </div>
+            <div className="flex items-start justify-between border-b pb-2 text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <MapPin className="h-4 w-4" /> Address
+              </span>
+              <span className="font-medium text-right">
+                {fullAddress || "N/A"}
+              </span>
+            </div>
+          </div>
+
+          {/* Primary contact — who to call */}
+          <div>
+            <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold text-foreground">
+              <UserStar className="h-4 w-4" /> Primary Contact
+            </h4>
+            {primaryContact ? (
+              <div className="rounded-lg border bg-card p-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <Link
+                    href={`/dashboard/people-directory/${primaryContact.person.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {primaryContact.person.name}
+                  </Link>
+                  {primaryContact.role ? (
+                    <span className="text-xs text-muted-foreground">
+                      {primaryContact.role}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+                  {primaryContact.person.email ? (
+                    <p className="break-all">{primaryContact.person.email}</p>
+                  ) : null}
+                  {primaryContact.person.phone ? (
+                    <p>{primaryContact.person.phone}</p>
+                  ) : null}
+                </div>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground italic">
+                No primary contact set.
+              </p>
+            )}
+          </div>
+
+          {/* Pinned note */}
+          {partner.notes ? (
+            <div>
+              <h4 className="mb-2 flex items-center gap-2 text-sm font-semibold text-foreground">
+                <StickyNote className="h-4 w-4" /> Quick Note
+              </h4>
+              <p className="rounded-lg border bg-muted/40 p-3 text-sm whitespace-pre-wrap">
+                {partner.notes}
+              </p>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {/* Right column */}
+      <div className="grid grid-cols-2 gap-4 content-start">
+        {tiles.map((tile) => (
+          <div key={tile.label} className="rounded-lg border bg-card p-4">
+            <div className="flex items-center gap-2">
+              <tile.icon className={cn("h-4 w-4", tile.color)} />
+              <span className="text-xs text-muted-foreground">
+                {tile.label}
+              </span>
+            </div>
+            <p className="mt-2 text-2xl font-bold">{tile.value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PartnerSectionCards;

--- a/components/dashboard/partners-directory/table/partners-directory-options.tsx
+++ b/components/dashboard/partners-directory/table/partners-directory-options.tsx
@@ -1,0 +1,60 @@
+import { PartnerType } from "@prisma/client";
+import {
+  Building2,
+  HeartHandshake,
+  Stethoscope,
+  Landmark,
+  CheckCircle2,
+  CircleSlash,
+} from "lucide-react";
+import { buildOptions, type OptionMeta } from "@/app/lib/utils/option-utils";
+
+const partnerTypeMeta: Record<PartnerType, OptionMeta> = {
+  SHELTER: {
+    label: "Shelter",
+    icon: Building2,
+    className:
+      "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-800",
+  },
+  RESCUE_GROUP: {
+    label: "Rescue Group",
+    icon: HeartHandshake,
+    className:
+      "bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950 dark:text-purple-300 dark:border-purple-800",
+  },
+  VET_CLINIC: {
+    label: "Vet Clinic",
+    icon: Stethoscope,
+    className:
+      "bg-teal-50 text-teal-700 border-teal-200 dark:bg-teal-950 dark:text-teal-300 dark:border-teal-800",
+  },
+  GOVERNMENT_AGENCY: {
+    label: "Government Agency",
+    icon: Landmark,
+    className:
+      "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950 dark:text-amber-300 dark:border-amber-800",
+  },
+};
+
+export const PartnerTypesOptions = buildOptions<PartnerType>(partnerTypeMeta);
+
+type ActiveStatusValue = "active" | "inactive";
+
+const activeStatusMeta: Record<ActiveStatusValue, OptionMeta> = {
+  active: {
+    label: "Active",
+    icon: CheckCircle2,
+    className:
+      "bg-green-50 text-green-700 border-green-200 dark:bg-green-950 dark:text-green-300 dark:border-green-800",
+  },
+  inactive: {
+    label: "Inactive",
+    icon: CircleSlash,
+    className:
+      "bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700",
+  },
+};
+
+export const ActiveStatusesOptions = buildOptions<ActiveStatusValue>(
+  activeStatusMeta,
+);

--- a/components/dashboard/partners-directory/table/partners-directory-table-columns.tsx
+++ b/components/dashboard/partners-directory/table/partners-directory-table-columns.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DataTableColumnHeader } from "../../../table-common/data-table-column-header";
+import { DataTableRowActions } from "./partners-directory-table-row-actions";
+import { PartnersDirectoryPayload } from "@/app/lib/types";
+import { PartnerTypesOptions, ActiveStatusesOptions } from "./partners-directory-options";
+
+export interface GetColumnsProps {
+  canManage: boolean;
+}
+
+export const getColumns = ({
+  canManage,
+}: GetColumnsProps): ColumnDef<PartnersDirectoryPayload>[] => [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-0.5"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-0.5"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Name" />
+    ),
+    cell: ({ row }) => {
+      return (
+        <Link
+          href={`/dashboard/partners-directory/${row.original.id}`}
+          className="font-medium hover:underline truncate"
+        >
+          {row.getValue("name")}
+        </Link>
+      );
+    },
+  },
+  {
+    accessorKey: "type",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Type" />
+    ),
+    cell: ({ row }) => {
+      const type = PartnerTypesOptions.find((t) => t.value === row.getValue("type"));
+      if (!type) return null;
+
+      const Icon = type.icon;
+      return (
+        <Badge variant="outline" className={type.className}>
+          <Icon className="mr-1 h-3 w-3" />
+          {type.label}
+        </Badge>
+      );
+    },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id));
+    },
+  },
+  {
+    id: "status",
+    accessorFn: (row) => (row.isActive ? "active" : "inactive"),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Status" />
+    ),
+    cell: ({ row }) => {
+      const status = ActiveStatusesOptions.find(
+        (s) => s.value === row.getValue("status"),
+      );
+      if (!status) return null;
+
+      const Icon = status.icon;
+      return (
+        <Badge variant="outline" className={status.className}>
+          <Icon className="mr-1 h-3 w-3" />
+          {status.label}
+        </Badge>
+      );
+    },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id));
+    },
+    enableSorting: false,
+  },
+  {
+    id: "contacts",
+    accessorFn: (row) => row._count.contacts,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Contacts" />
+    ),
+    cell: ({ row }) => {
+      const count = row.getValue("contacts") as number;
+      return (
+        <span className="tabular-nums">
+          {count > 0 ? (
+            count
+          ) : (
+            <span className="text-muted-foreground italic">—</span>
+          )}
+        </span>
+      );
+    },
+    enableSorting: false,
+  },
+  {
+    accessorKey: "email",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Email" />
+    ),
+    cell: ({ row }) => {
+      const email = row.getValue("email") as string | null;
+      return (
+        <span className="truncate">
+          {email || <span className="text-muted-foreground italic">—</span>}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "city",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="City" />
+    ),
+    cell: ({ row }) => {
+      const city = row.getValue("city") as string | null;
+      return (
+        <span className="truncate">
+          {city || <span className="text-muted-foreground italic">—</span>}
+        </span>
+      );
+    },
+  },
+  {
+    accessorKey: "state",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="State" />
+    ),
+    cell: ({ row }) => {
+      const state = row.getValue("state") as string | null;
+      return (
+        <span className="truncate">
+          {state || <span className="text-muted-foreground italic">—</span>}
+        </span>
+      );
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <DataTableRowActions row={row} canManage={canManage} />,
+  },
+];

--- a/components/dashboard/partners-directory/table/partners-directory-table-row-actions.tsx
+++ b/components/dashboard/partners-directory/table/partners-directory-table-row-actions.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Row } from "@tanstack/react-table";
+import { MoreHorizontal } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PartnersDirectoryPayload } from "@/app/lib/types";
+
+interface DataTableRowActionsProps {
+  row: Row<PartnersDirectoryPayload>;
+  canManage: boolean;
+}
+
+export function DataTableRowActions({
+  row,
+  canManage,
+}: DataTableRowActionsProps) {
+  const partner = row.original;
+
+  // Volunteers (read-only) get no row actions — every field is already
+  // visible in the table, and all actions here are mutations.
+  if (!canManage) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="flex h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href={`/dashboard/partners-directory/${partner.id}`}>
+            View Details
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link
+            href={`/dashboard/partners-directory/${partner.id}/edit?returnTo=/dashboard/partners-directory`}
+          >
+            Edit Partner Info
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/dashboard/partners-directory/table/partners-directory-table-toolbar.tsx
+++ b/components/dashboard/partners-directory/table/partners-directory-table-toolbar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Table } from "@tanstack/react-table";
+import { PartnersDirectoryPayload } from "@/app/lib/types";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { DataTableToolbar } from "@/components/table-common/data-table-toolbar";
+import { PartnerTypesOptions, ActiveStatusesOptions } from "./partners-directory-options";
+
+interface PartnersTableToolbarProps {
+  table: Table<PartnersDirectoryPayload>;
+}
+
+const PartnersTableToolbar = ({ table }: PartnersTableToolbarProps) => {
+  return (
+    <DataTableToolbar
+      table={table}
+      searchId="partners-search"
+      searchPlaceholder="Filter by name, email, or city..."
+      filterParamKeys={["type", "status"]}
+      filters={
+        <>
+          <ServerSideFacetedFilter
+            title="Type"
+            paramKey="type"
+            options={PartnerTypesOptions}
+          />
+          <ServerSideFacetedFilter
+            title="Status"
+            paramKey="status"
+            options={ActiveStatusesOptions}
+          />
+        </>
+      }
+    />
+  );
+};
+
+export default PartnersTableToolbar;

--- a/components/dashboard/partners-directory/tabs-nav/partner-nav-tabs.tsx
+++ b/components/dashboard/partners-directory/tabs-nav/partner-nav-tabs.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { Menu } from "lucide-react";
+import { LinkTabs } from "../../animals/tabs-nav/link-tabs";
+
+const partnerTabDefinitions = [
+  { suffix: "", label: "Animal History" },
+  { suffix: "/contacts", label: "Contacts" },
+  { suffix: "/notes", label: "Notes" },
+];
+
+export function PartnerNavTabs() {
+  const pathname = usePathname();
+
+  const basePath = pathname.split("/").slice(0, 4).join("/");
+
+  const dynamicLinks = partnerTabDefinitions.map((tab) => ({
+    href: `${basePath}${tab.suffix}`,
+    label: tab.label,
+  }));
+
+  return (
+    <div className="@container/tabs">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="w-32 @[581px]/tabs:hidden">
+          <Button variant="outline">
+            <Menu className="mr-2 h-4 w-4" />
+            Navigation
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-56" align="start">
+          <DropdownMenuGroup>
+            {dynamicLinks.map((link) => {
+              const isActive =
+                link.href === basePath
+                  ? pathname === link.href
+                  : pathname.startsWith(link.href);
+              return (
+                <Link key={link.href} href={link.href} passHref>
+                  <DropdownMenuItem
+                    className={cn(
+                      "cursor-pointer",
+                      isActive ? "bg-accent font-semibold" : "",
+                    )}
+                  >
+                    {link.label}
+                  </DropdownMenuItem>
+                </Link>
+              );
+            })}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <LinkTabs links={dynamicLinks} className="hidden @[581px]/tabs:block" />
+    </div>
+  );
+}

--- a/components/dashboard/people-directory/notes/person-note-actions.tsx
+++ b/components/dashboard/people-directory/notes/person-note-actions.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PersonNotePayload } from "@/app/lib/types";
+import {
+  deletePersonNote,
+  restorePersonNote,
+} from "@/app/lib/actions/person-note.actions";
+import { toast } from "sonner";
+import { PersonNoteForm } from "./person-note-form";
+
+interface PersonNoteActionsProps {
+  note: PersonNotePayload;
+  personId: string;
+}
+
+export function PersonNoteActions({ note, personId }: PersonNoteActionsProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deletePersonNote(note.id, personId).then((data) => {
+        if (data?.message) {
+          toast.success(data.message, {
+            action: {
+              label: "Undo",
+              onClick: () => onRestore(),
+            },
+          });
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restorePersonNote(note.id, personId).then((data) => {
+        if (data?.message) {
+          toast.success(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {note.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Edit Note</DialogTitle>
+          <DialogDescription>
+            Update the details for this note. Click update when you&apos;re
+            done.
+          </DialogDescription>
+        </DialogHeader>
+        <PersonNoteForm
+          personId={personId}
+          onFormSubmit={() => setIsDialogOpen(false)}
+          note={note}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dashboard/people-directory/notes/person-note-form.tsx
+++ b/components/dashboard/people-directory/notes/person-note-form.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { toast } from "sonner";
+import {
+  createPersonNote,
+  updatePersonNote,
+  type PersonNoteFormState,
+} from "@/app/lib/actions/person-note.actions";
+import { PersonNoteFormSchema } from "@/app/lib/zod-schemas/people-directory.schemas";
+import { PersonNotePayload } from "@/app/lib/types";
+
+const INITIAL_FORM_STATE: PersonNoteFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type PersonNoteFormValues = z.infer<typeof PersonNoteFormSchema>;
+
+interface Props {
+  personId: string;
+  onFormSubmit: () => void;
+  note?: PersonNotePayload;
+}
+
+export const PersonNoteForm = ({ personId, onFormSubmit, note }: Props) => {
+  const action = note
+    ? updatePersonNote.bind(null, note.id, personId)
+    : createPersonNote.bind(null, personId);
+
+  const [state, formAction, isPending] = useActionState<
+    PersonNoteFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<PersonNoteFormValues>({
+    resolver: zodResolver(PersonNoteFormSchema),
+    defaultValues: note ? { content: note.content } : { content: "" },
+  });
+
+  useEffect(() => {
+    if (!state.message) {
+      return;
+    }
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors && Object.keys(state.errors).length > 0) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof PersonNoteFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: PersonNoteFormValues) => {
+    const formData = new FormData();
+    formData.append("content", data.content);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Content</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Provide a detailed description of the note..."
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {note ? "Updating..." : "Creating..."}
+              </>
+            ) : note ? (
+              "Update Note"
+            ) : (
+              "Create Note"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/people-directory/notes/person-notes.tsx
+++ b/components/dashboard/people-directory/notes/person-notes.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { clsx } from "clsx";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { PersonNotePayload } from "@/app/lib/types";
+import { formatDateOrNA, formatTimeAgo } from "@/app/lib/utils/date-utils";
+import { SimplePagination } from "../../../simple-pagination";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ServerSideSort } from "@/components/table-common/server-side-sort";
+import { PersonNoteForm } from "./person-note-form";
+import { PersonNoteActions } from "./person-note-actions";
+
+const noteStatusOptions = [
+  { value: "active", label: "Active" },
+  { value: "deleted", label: "Deleted" },
+];
+
+interface Props {
+  notes: PersonNotePayload[];
+  totalPages: number;
+  personId: string;
+  canManage: boolean;
+}
+
+const PersonNotes = ({ notes, totalPages, personId, canManage }: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle>Person Notes</CardTitle>
+
+        <CardDescription>
+          Keep track of important notes about this person.
+        </CardDescription>
+
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button
+                variant={canManage ? "default" : "outline"}
+                size="sm"
+                className="disabled:pointer-events-auto disabled:cursor-not-allowed"
+                disabled={!canManage}
+              >
+                Add Note
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[600px]">
+              <DialogHeader>
+                <DialogTitle>Add Note</DialogTitle>
+                <DialogDescription>
+                  Add a new note for this person. Click create note when
+                  you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <PersonNoteForm
+                personId={personId}
+                onFormSubmit={() => setIsAddDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+
+        {/* Filter and Sort Controls */}
+        <div className="mt-4 flex flex-row flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2">
+            <ServerSideFacetedFilter
+              title="Status"
+              paramKey="status"
+              options={noteStatusOptions}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <ServerSideSort
+              paramKey="sort"
+              placeholder="Select order"
+              options={[
+                { label: "Newest First", value: "createdAt.desc" },
+                { label: "Oldest First", value: "createdAt.asc" },
+              ]}
+            />
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <div className="space-y-4">
+          {notes.length > 0 ? (
+            notes.map((note) => (
+              <div
+                key={note.id}
+                className={clsx(
+                  "border rounded-lg p-4 relative group",
+                  note.deletedAt && "opacity-60",
+                )}
+              >
+                {canManage && (
+                  <div className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <PersonNoteActions note={note} personId={personId} />
+                  </div>
+                )}
+
+                <div className="flex items-start gap-4">
+                  <div className="flex-1">
+                    {note.deletedAt && (
+                      <div className="mb-2">
+                        <Badge variant="destructive">Deleted</Badge>
+                      </div>
+                    )}
+
+                    <p className="text-sm text-gray-700 whitespace-pre-wrap">
+                      {note.content}
+                    </p>
+
+                    <div className="text-xs text-gray-500 mt-3">
+                      <span>{note.author?.name ?? "Unknown User"}</span>{" "}
+                      &middot;{" "}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="underline decoration-dotted cursor-help">
+                            {formatTimeAgo(note.createdAt)}
+                          </span>
+                        </TooltipTrigger>
+
+                        <TooltipContent>
+                          {formatDateOrNA(note.createdAt)}
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-12 border-2 border-dashed rounded-lg">
+              <p className="font-semibold text-lg">No Notes Found</p>
+
+              <p className="text-sm mt-1">
+                Try adjusting your filters or creating a new note.
+              </p>
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      <CardFooter>
+        <SimplePagination totalPages={totalPages} />
+      </CardFooter>
+    </Card>
+  );
+};
+
+export default PersonNotes;

--- a/components/dashboard/people-directory/tabs-nav/person-nav-tabs.tsx
+++ b/components/dashboard/people-directory/tabs-nav/person-nav-tabs.tsx
@@ -18,6 +18,7 @@ const personTabDefinitions = [
   { suffix: "", label: "Animal History" },
   { suffix: "/adoption-applications", label: "Adoption Applications" },
   { suffix: "/activity", label: "Activity" },
+  { suffix: "/notes", label: "Notes" },
 ];
 
 export function PersonNavTabs() {

--- a/components/skeletons/partnerSectionCardsSkeleton.tsx
+++ b/components/skeletons/partnerSectionCardsSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+const PartnerSectionCardsSkeleton = () => {
+  return (
+    <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <div className="flex items-start justify-between">
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-6 w-48" />
+              <Skeleton className="h-5 w-24" />
+            </div>
+            <Skeleton className="h-8 w-32" />
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-6 w-20" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex justify-between border-b pb-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+          <Skeleton className="h-20 w-full rounded-lg" />
+        </CardContent>
+      </Card>
+      <div className="grid grid-cols-2 gap-4 content-start">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="rounded-lg border p-4">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="mt-2 h-8 w-10" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PartnerSectionCardsSkeleton;

--- a/prisma/migrations/20260619170317_partner_contacts_and_notes/migration.sql
+++ b/prisma/migrations/20260619170317_partner_contacts_and_notes/migration.sql
@@ -1,0 +1,97 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `contactPerson` on the `partners` table. All the data in the column will be lost.
+  - The `notes` table is renamed to `animal_notes` (data preserved).
+
+*/
+-- AlterTable
+ALTER TABLE "breeds" ADD COLUMN     "deleted_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "colors" ADD COLUMN     "deleted_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "partners" DROP COLUMN "contactPerson",
+ADD COLUMN     "isActive" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "notes" TEXT,
+ADD COLUMN     "website" TEXT;
+
+-- AlterTable
+ALTER TABLE "species" ADD COLUMN     "deleted_at" TIMESTAMP(3);
+
+-- RenameTable (preserves all existing note data)
+ALTER TABLE "notes" RENAME TO "animal_notes";
+
+-- Rename the table's constraints and index to match the new table name
+ALTER TABLE "animal_notes" RENAME CONSTRAINT "notes_pkey" TO "animal_notes_pkey";
+ALTER TABLE "animal_notes" RENAME CONSTRAINT "notes_animal_id_fkey" TO "animal_notes_animal_id_fkey";
+ALTER TABLE "animal_notes" RENAME CONSTRAINT "notes_author_id_fkey" TO "animal_notes_author_id_fkey";
+ALTER INDEX "notes_animal_id_idx" RENAME TO "animal_notes_animal_id_idx";
+
+-- CreateTable
+CREATE TABLE "partner_contacts" (
+    "id" TEXT NOT NULL,
+    "partnerId" TEXT NOT NULL,
+    "personId" TEXT NOT NULL,
+    "role" TEXT,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "partner_contacts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "person_notes" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "person_id" TEXT NOT NULL,
+    "author_id" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "person_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "partner_notes" (
+    "id" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "partner_id" TEXT NOT NULL,
+    "author_id" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "partner_notes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "partner_contacts_partnerId_personId_key" ON "partner_contacts"("partnerId", "personId");
+
+-- CreateIndex
+CREATE INDEX "person_notes_person_id_idx" ON "person_notes"("person_id");
+
+-- CreateIndex
+CREATE INDEX "partner_notes_partner_id_idx" ON "partner_notes"("partner_id");
+
+-- AddForeignKey
+ALTER TABLE "partner_contacts" ADD CONSTRAINT "partner_contacts_partnerId_fkey" FOREIGN KEY ("partnerId") REFERENCES "partners"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_contacts" ADD CONSTRAINT "partner_contacts_personId_fkey" FOREIGN KEY ("personId") REFERENCES "persons"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "person_notes" ADD CONSTRAINT "person_notes_person_id_fkey" FOREIGN KEY ("person_id") REFERENCES "persons"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "person_notes" ADD CONSTRAINT "person_notes_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "persons"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_notes" ADD CONSTRAINT "partner_notes_partner_id_fkey" FOREIGN KEY ("partner_id") REFERENCES "partners"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "partner_notes" ADD CONSTRAINT "partner_notes_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "persons"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260619204125_partner_single_primary_contact/migration.sql
+++ b/prisma/migrations/20260619204125_partner_single_primary_contact/migration.sql
@@ -1,0 +1,6 @@
+-- At most one primary contact per partner.
+-- Partial unique index: the uniqueness only applies to rows where is_primary = true,
+-- so a partner can have many non-primary contacts but only one primary.
+CREATE UNIQUE INDEX "partner_contact_one_primary"
+  ON "partner_contacts" ("partnerId")
+  WHERE "isPrimary" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,16 +169,25 @@ model Partner {
   name String      @unique
   type PartnerType
 
-  // Contact Info
-  contactPerson String?
-  email         String?
-  phone         String?
-  address       String?
-  city          String?
-  state         String?
-  zipCode       String?
+  // Contact Info (the organization's own — for named people, see contacts below)
+  email   String?
+  phone   String?
+  website String?
+  address String?
+  city    String?
+  state   String?
+  zipCode String?
+
+  // Retire a partner without deleting it
+  isActive Boolean @default(true)
+
+  // Quick pinned blurb (e.g. "transfers weekdays only"). Dated history lives in partnerNotes.
+  notes String?
 
   // Back-relations
+  contacts     PartnerContact[]
+  partnerNotes PartnerNote[]
+
   transferredInAnimals  Intake[]
   transferredOutAnimals Outcome[]
 
@@ -186,6 +195,25 @@ model Partner {
   updatedAt DateTime @updatedAt
 
   @@map("partners")
+}
+
+// A Person can be a contact at many Partners, and a Partner can have many contacts
+model PartnerContact {
+  id        String  @id @default(cuid())
+  partnerId String
+  partner   Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
+  personId  String
+  person    Person  @relation(fields: [personId], references: [id])
+
+  role      String? // e.g., "Intake Coordinator", "Director", "After-hours line"
+  isPrimary Boolean @default(false)
+  isActive  Boolean @default(true) // false = no longer the contact, kept for history
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([partnerId, personId])
+  @@map("partner_contacts")
 }
 
 model Intake {
@@ -267,18 +295,18 @@ model Outcome {
 }
 
 model Animal {
-  id              String               @id @default(cuid())
+  id              String              @id @default(cuid())
   name            String
-  birthDate       DateTime             @map(name: "birth_date")
+  birthDate       DateTime            @map(name: "birth_date")
   sex             Sex
   size            AnimalSize?
-  weightKg        Float?               @map(name: "weight_kg")
-  heightCm        Float?               @map(name: "height_cm")
+  weightKg        Float?              @map(name: "weight_kg")
+  heightCm        Float?              @map(name: "height_cm")
   city            String?
   state           String?
   description     String?
-  listingStatus   AnimalListingStatus  @default(DRAFT)
-  microchipNumber String?              @unique
+  listingStatus   AnimalListingStatus @default(DRAFT)
+  microchipNumber String?             @unique
   archiveReason   OutcomeType? /// Should only be set when listingStatus is ARCHIVED. Explains why the animal is no longer available.
 
   // Relations
@@ -290,7 +318,7 @@ model Animal {
   characteristics      Characteristic[]
   animalImages         AnimalImage[]
   medicalRecords       MedicalRecord[]
-  notes                Note[]
+  notes                AnimalNote[]
   tasks                Task[]
   likes                Like[]
   adoptionApplications AdoptionApplication[]
@@ -327,8 +355,9 @@ model Species {
   animals Animal[]
   breeds  Breed[] // A species can have many breeds
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? @map(name: "deleted_at")
 
   @@map(name: "species")
 }
@@ -340,8 +369,9 @@ model Breed {
   speciesId String   @map(name: "species_id")
   species   Species  @relation(fields: [speciesId], references: [id])
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? @map(name: "deleted_at")
 
   @@unique([name, speciesId])
   @@map(name: "breeds")
@@ -352,8 +382,9 @@ model Color {
   name    String   @unique // "Black", "White", "Brown", "Brindle", "Tabby"
   animals Animal[]
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? @map(name: "deleted_at")
 
   @@map(name: "colors")
 }
@@ -374,7 +405,7 @@ model Characteristic {
   @@map("characteristics")
 }
 
-model Note {
+model AnimalNote {
   id       String       @id @default(cuid())
   category NoteCategory
   content  String
@@ -383,14 +414,52 @@ model Note {
   animal   Animal @relation(fields: [animalId], references: [id], onDelete: Cascade)
 
   authorId String? @map(name: "author_id")
-  author   Person? @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  author   Person? @relation("AnimalNoteAuthor", fields: [authorId], references: [id], onDelete: SetNull)
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   deletedAt DateTime? @map(name: "deleted_at")
 
   @@index([animalId])
-  @@map(name: "notes")
+  @@map(name: "animal_notes")
+}
+
+// Dated log of notes about a Person (e.g. "called 6/12, declined to foster").
+model PersonNote {
+  id      String @id @default(cuid())
+  content String
+
+  personId String @map(name: "person_id")
+  person   Person @relation("PersonNoteSubject", fields: [personId], references: [id], onDelete: Cascade)
+
+  authorId String? @map(name: "author_id")
+  author   Person? @relation("PersonNoteAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? @map(name: "deleted_at")
+
+  @@index([personId])
+  @@map("person_notes")
+}
+
+// Dated log of notes about a Partner organization.
+model PartnerNote {
+  id      String @id @default(cuid())
+  content String
+
+  partnerId String  @map(name: "partner_id")
+  partner   Partner @relation(fields: [partnerId], references: [id], onDelete: Cascade)
+
+  authorId String? @map(name: "author_id")
+  author   Person? @relation("PartnerNoteAuthor", fields: [authorId], references: [id], onDelete: SetNull)
+
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  deletedAt DateTime? @map(name: "deleted_at")
+
+  @@index([partnerId])
+  @@map("partner_notes")
 }
 
 model Task {
@@ -444,8 +513,8 @@ model MedicalRecord {
 
 /// Stores the application and approval status for a user wanting to become a foster parent.
 model FosterProfile {
-  id        String   @id @default(cuid())
-  isActive  Boolean  @default(false) @map(name: "is_active")
+  id            String  @id @default(cuid())
+  isActive      Boolean @default(false) @map(name: "is_active")
   internalNotes String?
 
   animalsFostered Animal[]
@@ -573,9 +642,9 @@ model AnimalImage {
 }
 
 model Person {
-  id      String     @id @default(cuid())
+  id      String  @id @default(cuid())
   name    String
-  email   String?    @unique
+  email   String? @unique
   phone   String?
   address String?
   city    String?
@@ -586,13 +655,17 @@ model Person {
   user User?
 
   // Back-relations to all their interactions
-  fosterProfile            FosterProfile?
+  fosterProfile    FosterProfile?
   householdProfile HouseholdProfile?
-  
+
   adoptionApplications     AdoptionApplication[]
   applicationStatusHistory ApplicationStatusHistory[]
   likes                    Like[]
-  notesAuthored            Note[]
+  animalNotesAuthored      AnimalNote[]               @relation("AnimalNoteAuthor")
+  personNotesAuthored      PersonNote[]               @relation("PersonNoteAuthor")
+  partnerNotesAuthored     PartnerNote[]              @relation("PartnerNoteAuthor")
+  personNotes              PersonNote[]               @relation("PersonNoteSubject") // notes written ABOUT this person
+  partnerContacts          PartnerContact[]
   tasksAssigned            Task[]                     @relation("TasksAssignedTo")
   tasksCreated             Task[]                     @relation("TasksCreatedBy")
   reclaimedAnimalsAsOwner  Outcome[]                  @relation("ReclaimedByOwner")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -945,8 +945,52 @@ async function seedChartData() {
   console.log("Seeded bulk chart data.");
 }
 
+async function clearDatabase() {
+  console.log("Clearing existing data...");
+
+  await prisma.medicationLog.deleteMany();
+  await prisma.medicationSchedule.deleteMany();
+  await prisma.assessmentField.deleteMany();
+  await prisma.assessment.deleteMany();
+  await prisma.animalActivityLog.deleteMany();
+  await prisma.task.deleteMany();
+  await prisma.intake.deleteMany();
+  await prisma.outcome.deleteMany();
+  await prisma.applicationStatusHistory.deleteMany();
+  await prisma.adoptionApplication.deleteMany();
+
+  await prisma.animalNote.deleteMany();
+  await prisma.personNote.deleteMany();
+  await prisma.partnerNote.deleteMany();
+  await prisma.partnerContact.deleteMany();
+  await prisma.like.deleteMany();
+
+  await prisma.fosterProfile.deleteMany();
+  await prisma.householdProfile.deleteMany();
+
+  await prisma.animalImage.deleteMany();
+  await prisma.medicalRecord.deleteMany();
+  await prisma.animal.deleteMany();
+
+  await prisma.assessmentTemplate.deleteMany();
+
+  await prisma.partner.deleteMany();
+
+  await prisma.breed.deleteMany();
+  await prisma.species.deleteMany();
+  await prisma.color.deleteMany();
+  await prisma.characteristic.deleteMany();
+
+  await prisma.account.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.person.deleteMany();
+
+  console.log("Cleared existing data.");
+}
+
 export async function main() {
   console.log("Start seeding new data...");
+  await clearDatabase();
   await seedPersonsAndUsers();
   await seedLookupTables();
   await seedPartners();

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -18,6 +18,7 @@ import {
   AssessmentOutcome,
   FieldType,
   OutcomeType,
+  Prisma,
 } from "@prisma/client";
 import { isDemo } from "@/lib/flags";
 import {
@@ -179,13 +180,13 @@ const allCharacteristics = {
   },
 };
 
-const partnerData = [
+const partnerData: Prisma.PartnerCreateManyInput[] = [
   {
     name: "City Animal Control",
     type: PartnerType.GOVERNMENT_AGENCY,
-    contactPerson: "Officer Dave",
     email: "contact@cityanimalcontrol.gov",
     phone: "555-0101",
+    website: "https://cityanimalcontrol.gov",
     address: "123 Public Works Rd",
     city: "New York",
     state: "NY",
@@ -194,9 +195,9 @@ const partnerData = [
   {
     name: "Second Chance Rescue",
     type: PartnerType.RESCUE_GROUP,
-    contactPerson: "Sarah Jones",
     email: "sarah@secondchancerescue.org",
     phone: "555-0102",
+    website: "https://secondchancerescue.org",
     address: "456 Rescue Ave",
     city: "New York",
     state: "NY",
@@ -205,9 +206,9 @@ const partnerData = [
   {
     name: "Downtown Veterinary Clinic",
     type: PartnerType.VET_CLINIC,
-    contactPerson: "Dr. Emily White",
     email: "reception@downtownvet.com",
     phone: "555-0103",
+    website: "https://downtownvet.com",
     address: "789 Health St",
     city: "New York",
     state: "NY",
@@ -793,7 +794,7 @@ async function seedAnimalsAndRelations() {
         },
       });
 
-      await prisma.note.create({
+      await prisma.animalNote.create({
         data: {
           animalId: animal.id,
           authorId: processingStaff.id,


### PR DESCRIPTION
Builds out the notes feature across Partner and Person profiles, and
brings animal notes' delete-visibility UI in line with both.

### Partner directory
- Partner directory table, profile (Animal History / Contacts / Notes tabs)
- Full contact management: add/edit via dialog, set-primary with undo,
  deactivate/reactivate, person-picker (preloaded client-side filter)
- Single-primary-contact invariant enforced via a partial unique index
- Partner notes: paginated, sortable, soft-delete

### Person notes
- New Notes tab on the person profile (`/people-directory/[id]/notes`)
- Paginated fetch with sort (newest/oldest) and an Active/Deleted status
  filter; default view shows active only, deleted shown on demand
- Add/edit dialog, soft-delete with delete→undo→restore toast
- Author stamped from the session; subject is the profile's person
- Gated: PERSONS_READ to view, PERSONS_MANAGE to manage

### Animal notes
- Replaced the show-deleted toggle with an Active/Deleted faceted filter
  (matches partner/person notes), category filter preserved alongside it
- Gated the row actions dropdown behind canManage