### PR TITLE
Add Characteristics Catalog management

### DIFF
--- a/app/dashboard/settings/characteristics/page.tsx
+++ b/app/dashboard/settings/characteristics/page.tsx
@@ -1,0 +1,24 @@
+import CharacteristicsCatalog from "@/components/dashboard/settings/characteristics/characteristics-catalog";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { fetchCharacteristicsCatalog } from "@/app/lib/data/animals/characteristics-catalog.data";
+
+const Page = async () => {
+  return (
+    <Authorize
+      permission={AppPermissions.MANAGE_CHARACTERISTICS_CATALOG}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent />
+    </Authorize>
+  );
+};
+
+const PageContent = async () => {
+  const characteristics = await fetchCharacteristicsCatalog();
+
+  return <CharacteristicsCatalog characteristics={characteristics} />;
+};
+
+export default Page;

--- a/app/lib/actions/characteristics-catalog.actions.ts
+++ b/app/lib/actions/characteristics-catalog.actions.ts
@@ -1,0 +1,204 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { CharacteristicFormSchema } from "../zod-schemas/characteristic.schemas";
+
+export interface CharacteristicFormState {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    name?: string[];
+    category?: string[];
+  };
+}
+
+// Shared duplicate check: case-insensitive, global (name is unique across the
+// whole table regardless of category), ignores the row being edited (so
+// renaming a characteristic to itself doesn't collide).
+const findDuplicate = async (name: string, excludeId?: string) => {
+  return prisma.characteristic.findFirst({
+    where: {
+      name: { equals: name, mode: "insensitive" },
+      deletedAt: null,
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { id: true },
+  });
+};
+
+const _createCharacteristic = async (
+  prevState: CharacteristicFormState,
+  formData: FormData,
+): Promise<CharacteristicFormState> => {
+  const validatedFields = CharacteristicFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create characteristic.",
+    };
+  }
+
+  const { name, category } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name);
+    if (existing) {
+      return {
+        success: false,
+        message: "A characteristic with that name already exists.",
+      };
+    }
+
+    await prisma.characteristic.create({ data: { name, category } });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A characteristic with that name already exists.",
+      };
+    }
+    console.error("Database Error creating characteristic:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create characteristic.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/characteristics");
+  return { success: true, message: "Characteristic created successfully." };
+};
+
+const _updateCharacteristic = async (
+  characteristicId: string,
+  prevState: CharacteristicFormState,
+  formData: FormData,
+): Promise<CharacteristicFormState> => {
+  const parsedId = cuidSchema.safeParse(characteristicId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid characteristic ID format." };
+  }
+
+  const validatedFields = CharacteristicFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update characteristic.",
+    };
+  }
+
+  const { name, category } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name, parsedId.data);
+    if (existing) {
+      return {
+        success: false,
+        message: "A characteristic with that name already exists.",
+      };
+    }
+
+    await prisma.characteristic.update({
+      where: { id: parsedId.data },
+      data: { name, category },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A characteristic with that name already exists.",
+      };
+    }
+    console.error("Database Error updating characteristic:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update characteristic.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/characteristics");
+  return { success: true, message: "Characteristic updated successfully." };
+};
+
+const _deleteCharacteristic = async (
+  characteristicId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(characteristicId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid characteristic ID format." };
+  }
+
+  try {
+    await prisma.characteristic.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: new Date() },
+    });
+    revalidatePath("/dashboard/settings/characteristics");
+    return { success: true, message: "Characteristic deleted successfully." };
+  } catch (error) {
+    console.error("Database Error deleting characteristic:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to delete characteristic.",
+    };
+  }
+};
+
+const _restoreCharacteristic = async (
+  characteristicId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(characteristicId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid characteristic ID format." };
+  }
+
+  try {
+    await prisma.characteristic.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: null },
+    });
+    revalidatePath("/dashboard/settings/characteristics");
+    return { success: true, message: "Characteristic restored successfully." };
+  } catch (error) {
+    console.error("Database Error restoring characteristic:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to restore characteristic.",
+    };
+  }
+};
+
+export const createCharacteristic = RequirePermission(
+  AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
+)(_createCharacteristic);
+
+export const updateCharacteristic = RequirePermission(
+  AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
+)(_updateCharacteristic);
+
+export const deleteCharacteristic = RequirePermission(
+  AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
+)(_deleteCharacteristic);
+
+export const restoreCharacteristic = RequirePermission(
+  AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
+)(_restoreCharacteristic);

--- a/app/lib/constants/characteristic-categories.tsx
+++ b/app/lib/constants/characteristic-categories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { CharacteristicCategory } from "@prisma/client";
+import {
+  HeartPulse,
+  Stethoscope,
+  Home,
+  FileText,
+  PlusCircle,
+} from "lucide-react";
+
+export type CategoryUIDefinition = {
+  label: string;
+  color: string;
+  icon: React.ElementType;
+};
+
+export const CATEGORIES: Record<CharacteristicCategory, CategoryUIDefinition> = {
+  [CharacteristicCategory.BEHAVIOR]: {
+    label: "Behavior",
+    color:
+      "bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-900 dark:hover:bg-blue-950",
+    icon: HeartPulse,
+  },
+  [CharacteristicCategory.MEDICAL]: {
+    label: "Medical",
+    color:
+      "bg-red-100 text-red-800 border-red-200 hover:bg-red-100 dark:bg-red-950 dark:text-red-300 dark:border-red-900 dark:hover:bg-red-950",
+    icon: Stethoscope,
+  },
+  [CharacteristicCategory.ENVIRONMENT]: {
+    label: "Environment",
+    color:
+      "bg-green-100 text-green-800 border-green-200 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:border-green-900 dark:hover:bg-green-950",
+    icon: Home,
+  },
+  [CharacteristicCategory.ADMINISTRATIVE]: {
+    label: "Administrative",
+    color:
+      "bg-gray-100 text-gray-800 border-gray-200 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700 dark:hover:bg-gray-800",
+    icon: FileText,
+  },
+  [CharacteristicCategory.OTHER]: {
+    label: "Other",
+    color:
+      "bg-yellow-100 text-yellow-800 border-yellow-200 hover:bg-yellow-100 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-900 dark:hover:bg-yellow-950",
+    icon: PlusCircle,
+  },
+};
+
+export const CATEGORY_KEYS = Object.values(CharacteristicCategory);

--- a/app/lib/data/animals/characteristics-catalog.data.ts
+++ b/app/lib/data/animals/characteristics-catalog.data.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@/app/lib/prisma";
+import { Characteristic } from "@prisma/client";
+import { RequirePermission } from "../../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+
+const _fetchCharacteristicsCatalog = async (): Promise<Characteristic[]> => {
+  try {
+    // Management view: return everything, including soft-deleted rows
+    return await prisma.characteristic.findMany({
+      orderBy: [{ category: "asc" }, { name: "asc" }],
+    });
+  } catch (error) {
+    console.error("Failed to fetch characteristics catalog:", error);
+    throw new Error("Could not fetch characteristics.");
+  }
+};
+
+export const fetchCharacteristicsCatalog = RequirePermission(
+  AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
+)(_fetchCharacteristicsCatalog);

--- a/app/lib/data/public.data.ts
+++ b/app/lib/data/public.data.ts
@@ -173,6 +173,9 @@ export const fetchPublicPagePetById = async (id: string) => {
           },
         },
         characteristics: {
+          where: {
+            deletedAt: null,
+          },
           select: {
             name: true,
           },

--- a/app/lib/zod-schemas/characteristic.schemas.ts
+++ b/app/lib/zod-schemas/characteristic.schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { CharacteristicCategory } from "@prisma/client";
+
+export const CharacteristicFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .transform((s) => s.replace(/\s+/g, " ")) // collapse internal whitespace
+    .pipe(z.string().min(1, "Name is required.").max(100, "Name is too long.")),
+  category: z.enum(CharacteristicCategory),
+});

--- a/components/dashboard/animals/characteristics/characteristics.tsx
+++ b/components/dashboard/animals/characteristics/characteristics.tsx
@@ -6,11 +6,6 @@ import { clsx } from "clsx";
 import {
   X,
   PlusCircle,
-  Pencil,
-  HeartPulse,
-  Stethoscope,
-  Home,
-  FileText,
   ChevronsUpDown,
   Loader2,
 } from "lucide-react";
@@ -50,45 +45,7 @@ import {
 import { CharacteristicWithAssignment } from "@/app/lib/data/animals/animal-characteristics.data";
 import { updateAnimalCharacteristics } from "@/app/lib/actions/animal-characteristics.actions";
 import { toast } from "sonner";
-
-type CategoryUIDefinition = {
-  label: string;
-  color: string;
-  icon: React.ElementType;
-};
-
-const CATEGORIES: Record<CharacteristicCategory, CategoryUIDefinition> = {
-  [CharacteristicCategory.BEHAVIOR]: {
-    label: "Behavior",
-    color:
-      "bg-blue-100 text-blue-800 border-blue-200 hover:bg-blue-100 dark:bg-blue-950 dark:text-blue-300 dark:border-blue-900 dark:hover:bg-blue-950",
-    icon: HeartPulse,
-  },
-  [CharacteristicCategory.MEDICAL]: {
-    label: "Medical",
-    color:
-      "bg-red-100 text-red-800 border-red-200 hover:bg-red-100 dark:bg-red-950 dark:text-red-300 dark:border-red-900 dark:hover:bg-red-950",
-    icon: Stethoscope,
-  },
-  [CharacteristicCategory.ENVIRONMENT]: {
-    label: "Environment",
-    color:
-      "bg-green-100 text-green-800 border-green-200 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:border-green-900 dark:hover:bg-green-950",
-    icon: Home,
-  },
-  [CharacteristicCategory.ADMINISTRATIVE]: {
-    label: "Administrative",
-    color:
-      "bg-gray-100 text-gray-800 border-gray-200 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700 dark:hover:bg-gray-800",
-    icon: FileText,
-  },
-  [CharacteristicCategory.OTHER]: {
-    label: "Other",
-    color:
-      "bg-yellow-100 text-yellow-800 border-yellow-200 hover:bg-yellow-100 dark:bg-yellow-950 dark:text-yellow-300 dark:border-yellow-900 dark:hover:bg-yellow-950",
-    icon: PlusCircle,
-  },
-};
+import { CATEGORIES } from "@/app/lib/constants/characteristic-categories";
 
 const CATEGORY_KEYS = Object.values(CharacteristicCategory);
 

--- a/components/dashboard/settings/characteristics/characteristic-actions.tsx
+++ b/components/dashboard/settings/characteristics/characteristic-actions.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Characteristic } from "@prisma/client";
+import { CharacteristicForm } from "./characteristic-form";
+import {
+  deleteCharacteristic,
+  restoreCharacteristic,
+} from "@/app/lib/actions/characteristics-catalog.actions";
+import { toast } from "sonner";
+
+interface Props {
+  characteristic: Characteristic;
+}
+
+export function CharacteristicActions({ characteristic }: Props) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deleteCharacteristic(characteristic.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message, {
+            action: {
+              label: "Undo",
+              onClick: () => onRestore(),
+            },
+          });
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restoreCharacteristic(characteristic.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message);
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {characteristic.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Edit Characteristic</DialogTitle>
+          <DialogDescription>
+            Update the name or category for this characteristic. Click update
+            when you&apos;re done.
+          </DialogDescription>
+        </DialogHeader>
+        <CharacteristicForm
+          onFormSubmit={() => setIsDialogOpen(false)}
+          characteristic={characteristic}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dashboard/settings/characteristics/characteristic-form.tsx
+++ b/components/dashboard/settings/characteristics/characteristic-form.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Characteristic, CharacteristicCategory } from "@prisma/client";
+import {
+  CharacteristicFormState,
+  createCharacteristic,
+  updateCharacteristic,
+} from "@/app/lib/actions/characteristics-catalog.actions";
+import { CharacteristicFormSchema } from "@/app/lib/zod-schemas/characteristic.schemas";
+import { CATEGORIES, CATEGORY_KEYS } from "@/app/lib/constants/characteristic-categories";
+import { toast } from "sonner";
+
+const INITIAL_FORM_STATE: CharacteristicFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type CharacteristicFormValues = z.infer<typeof CharacteristicFormSchema>;
+
+interface Props {
+  onFormSubmit: () => void; // To close the dialog on success
+  characteristic?: Characteristic;
+}
+
+export const CharacteristicForm = ({ onFormSubmit, characteristic }: Props) => {
+  const action = characteristic
+    ? updateCharacteristic.bind(null, characteristic.id)
+    : createCharacteristic;
+
+  const [state, formAction, isPending] = useActionState<
+    CharacteristicFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<CharacteristicFormValues>({
+    resolver: zodResolver(CharacteristicFormSchema),
+    defaultValues: characteristic
+      ? {
+        name: characteristic.name,
+        category: characteristic.category,
+      }
+      : {
+        name: "",
+        category: CharacteristicCategory.BEHAVIOR,
+      },
+  });
+
+  useEffect(() => {
+    if (!state.message) {
+      return;
+    }
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof CharacteristicFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: CharacteristicFormValues) => {
+    const formData = new FormData();
+    formData.append("name", data.name);
+    formData.append("category", data.category);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <div className="grid grid-cols-1 gap-4">
+          {/* Name */}
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="name">Name</FormLabel>
+                <FormControl>
+                  <Input
+                    id="name"
+                    placeholder="e.g. Good with kids"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Category */}
+          <FormField
+            control={form.control}
+            name="category"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="category">Category</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  name={field.name}
+                >
+                  <FormControl>
+                    <SelectTrigger className="w-full" id="category">
+                      <SelectValue placeholder="Select a category" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {CATEGORY_KEYS.map((key) => (
+                      <SelectItem key={key} value={key}>
+                        {CATEGORIES[key].label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {characteristic ? "Updating..." : "Creating..."}
+              </>
+            ) : characteristic ? (
+              "Update Characteristic"
+            ) : (
+              "Create Characteristic"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/settings/characteristics/characteristics-catalog.tsx
+++ b/components/dashboard/settings/characteristics/characteristics-catalog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import { Characteristic, CharacteristicCategory } from "@prisma/client";
+import { clsx } from "clsx";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { PlusCircle } from "lucide-react";
+import {
+  CATEGORIES,
+  CATEGORY_KEYS,
+} from "@/app/lib/constants/characteristic-categories";
+import { CharacteristicForm } from "./characteristic-form";
+import { CharacteristicActions } from "./characteristic-actions";
+
+interface Props {
+  characteristics: Characteristic[];
+}
+
+const CharacteristicsCatalog = ({ characteristics }: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  const groupedCharacteristics = characteristics.reduce
+    <Record<CharacteristicCategory, Characteristic[]>
+    >(
+      (acc, char) => {
+        (acc[char.category] = acc[char.category] || []).push(char);
+        return acc;
+      },
+      {} as Record<CharacteristicCategory, Characteristic[]>,
+    );
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle className="@[650px]/card:text-xl">
+          Characteristics
+        </CardTitle>
+        <CardDescription>
+          Manage the catalog of tags used to describe animals across the
+          shelter.
+        </CardDescription>
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <PlusCircle className="size-4 mr-2" />
+                Add Characteristic
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[480px]">
+              <DialogHeader>
+                <DialogTitle>Add Characteristic</DialogTitle>
+                <DialogDescription>
+                  Create a new characteristic for the catalog. Click create when
+                  you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <CharacteristicForm
+                onFormSubmit={() => setIsAddDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {CATEGORY_KEYS.map((key) => {
+            const Icon = CATEGORIES[key].icon;
+            const characteristicsForCategory = groupedCharacteristics[key];
+            return (
+              characteristicsForCategory &&
+              characteristicsForCategory.length > 0 && (
+                <div key={key} className="border rounded-lg p-4 bg-card">
+                  <h4 className="font-medium mb-3 flex items-center gap-2 text-foreground">
+                    <Icon className="h-5 w-5 text-muted-foreground" />
+                    {CATEGORIES[key].label}
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {characteristicsForCategory.map((char) => (
+                      <div
+                        key={char.id}
+                        className={clsx(
+                          "flex items-center gap-1 rounded-md border pl-2.5 pr-1 py-0.5",
+                          char.deletedAt
+                            ? "opacity-50 border-dashed"
+                            : CATEGORIES[char.category]?.color,
+                        )}
+                      >
+                        <span className="text-sm font-medium">
+                          {char.name}
+                        </span>
+                        {char.deletedAt && (
+                          <Badge
+                            variant="destructive"
+                            className="ml-1 text-[10px] px-1 py-0"
+                          >
+                            Deleted
+                          </Badge>
+                        )}
+                        <CharacteristicActions characteristic={char} />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )
+            );
+          })}
+
+          {characteristics.length === 0 && (
+            <div className="text-center py-8 px-4 border-2 border-dashed rounded-lg">
+              <p className="text-muted-foreground text-sm">
+                No characteristics have been created yet.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => setIsAddDialogOpen(true)}
+              >
+                <PlusCircle className="size-4 mr-2" />
+                Add Characteristic
+              </Button>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CharacteristicsCatalog;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  reactCompiler: false,
   images: {
     // Allow loading images from specific remote domains
     remotePatterns: [

--- a/prisma/migrations/20260624163306_characteristic_name_globally_unique/migration.sql
+++ b/prisma/migrations/20260624163306_characteristic_name_globally_unique/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `characteristics` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "characteristics_name_category_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "characteristics_name_key" ON "characteristics"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -391,7 +391,7 @@ model Color {
 
 model Characteristic {
   id       String                 @id @default(cuid())
-  name     String // e.g., "Good with Kids", "Bite History", "Deaf"
+  name     String                 @unique // Globally unique; a trait is identified by name alone, regardless of category
   category CharacteristicCategory // The group this tag belongs to (BEHAVIOR, MEDICAL, etc.)
 
   // A list of all animals that have this characteristic
@@ -401,7 +401,6 @@ model Characteristic {
   updatedAt DateTime  @updatedAt
   deletedAt DateTime? @map(name: "deleted_at")
 
-  @@unique([name, category]) // Ensures "Deaf (MEDICAL)" is unique, etc.
   @@map("characteristics")
 }
 


### PR DESCRIPTION
## What
Adds an admin-only Characteristics Catalog under Settings, for managing the vocabulary of tags used to describe animals.

## Changes
- New catalog page at `/dashboard/settings/characteristics`, grouped by category
- Full CRUD: create, rename, recategorize, soft-delete, restore
- Per-item actions menu with delete + Undo toast and restore
- New `MANAGE_CHARACTERISTICS_CATALOG` permission (admin-only), enforced server-side on every action
- Global, case-insensitive name uniqueness, enforced at the app layer and via DB migration
- Name normalization: trim + collapse internal whitespace; original casing preserved

## Migration
- Replaces `@@unique([name, category])` with a single-column `@unique` on `name`

## Notes
- Possible follow-up: show per-tag usage count.