### PR TITLE
Add Animal Taxonomy management (species, breeds, colors)

### DIFF
--- a/app/dashboard/settings/animal-taxonomy/page.tsx
+++ b/app/dashboard/settings/animal-taxonomy/page.tsx
@@ -1,0 +1,38 @@
+import { ColorsSection } from "@/components/dashboard/settings/animal-taxonomy/colors-section";
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { fetchColorsCatalog } from "@/app/lib/data/colors/olors-catalog.data";
+import { fetchSpeciesCatalog } from "@/app/lib/data/species/species-catalog.data";
+import { fetchBreedsCatalog } from "@/app/lib/data/breeds/breeds-catalog.data";
+import { SpeciesSection } from "@/components/dashboard/settings/animal-taxonomy/species-section";
+import { BreedsSection } from "@/components/dashboard/settings/animal-taxonomy/breeds-section";
+
+const Page = async () => {
+  return (
+    <Authorize
+      permission={AppPermissions.MANAGE_ANIMAL_TAXONOMY}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent />
+    </Authorize>
+  );
+};
+
+const PageContent = async () => {
+  const [colors, species, breeds] = await Promise.all([
+    fetchColorsCatalog(),
+    fetchSpeciesCatalog(),
+    fetchBreedsCatalog(),
+  ]);
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <ColorsSection colors={colors} />
+      <SpeciesSection species={species} />
+      <BreedsSection breeds={breeds} species={species} />
+    </div>
+  );
+};
+
+export default Page;

--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -32,6 +32,13 @@ const settingsCards: readonly SettingsCard[] = [
         permission: AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
     },
     {
+        title: "Animal Taxonomy",
+        description:
+            "Manage species, breeds, and colors used to describe animals.",
+        url: "/dashboard/settings/animal-taxonomy",
+        permission: AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+    },
+    {
         title: "Assessment Templates",
         description:
             "Create and edit the templates staff use to assess animals.",

--- a/app/lib/actions/breeds-catalog.actions.ts
+++ b/app/lib/actions/breeds-catalog.actions.ts
@@ -1,0 +1,232 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { BreedFormSchema } from "../zod-schemas/taxonomy.schemas";
+
+export interface BreedFormState {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    name?: string[];
+    speciesId?: string[];
+  };
+}
+
+// Duplicate check scoped per species (matches @@unique([name, speciesId])).
+const findDuplicate = async (
+  name: string,
+  speciesId: string,
+  excludeId?: string,
+) => {
+  return prisma.breed.findFirst({
+    where: {
+      speciesId,
+      name: { equals: name, mode: "insensitive" },
+      deletedAt: null,
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { id: true },
+  });
+};
+
+// Ensure the chosen species exists and isn't soft-deleted.
+const isActiveSpecies = async (speciesId: string) => {
+  const species = await prisma.species.findFirst({
+    where: { id: speciesId, deletedAt: null },
+    select: { id: true },
+  });
+  return Boolean(species);
+};
+
+const _createBreed = async (
+  prevState: BreedFormState,
+  formData: FormData,
+): Promise<BreedFormState> => {
+  const validatedFields = BreedFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create breed.",
+    };
+  }
+
+  const { name, speciesId } = validatedFields.data;
+
+  try {
+    if (!(await isActiveSpecies(speciesId))) {
+      return {
+        success: false,
+        message: "The selected species no longer exists.",
+      };
+    }
+
+    const existing = await findDuplicate(name, speciesId);
+    if (existing) {
+      return {
+        success: false,
+        message: "A breed with that name already exists for this species.",
+      };
+    }
+
+    await prisma.breed.create({ data: { name, speciesId } });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A breed with that name already exists for this species.",
+      };
+    }
+    console.error("Database Error creating breed:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create breed.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Breed created successfully." };
+};
+
+const _updateBreed = async (
+  breedId: string,
+  prevState: BreedFormState,
+  formData: FormData,
+): Promise<BreedFormState> => {
+  const parsedId = cuidSchema.safeParse(breedId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid breed ID format." };
+  }
+
+  const validatedFields = BreedFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update breed.",
+    };
+  }
+
+  const { name, speciesId } = validatedFields.data;
+
+  try {
+    if (!(await isActiveSpecies(speciesId))) {
+      return {
+        success: false,
+        message: "The selected species no longer exists.",
+      };
+    }
+
+    const existing = await findDuplicate(name, speciesId, parsedId.data);
+    if (existing) {
+      return {
+        success: false,
+        message: "A breed with that name already exists for this species.",
+      };
+    }
+
+    await prisma.breed.update({
+      where: { id: parsedId.data },
+      data: { name, speciesId },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A breed with that name already exists for this species.",
+      };
+    }
+    console.error("Database Error updating breed:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update breed.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Breed updated successfully." };
+};
+
+const _deleteBreed = async (
+  breedId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(breedId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid breed ID format." };
+  }
+
+  try {
+    // Breeds delete freely (soft). Consumption views filter deletedAt: null,
+    // so an animal still linked to a deleted breed simply won't display it.
+    await prisma.breed.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: new Date() },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Breed deleted successfully." };
+  } catch (error) {
+    console.error("Database Error deleting breed:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to delete breed.",
+    };
+  }
+};
+
+const _restoreBreed = async (
+  breedId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(breedId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid breed ID format." };
+  }
+
+  try {
+    await prisma.breed.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: null },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Breed restored successfully." };
+  } catch (error) {
+    console.error("Database Error restoring breed:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to restore breed.",
+    };
+  }
+};
+
+export const createBreed = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_createBreed);
+
+export const updateBreed = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_updateBreed);
+
+export const deleteBreed = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_deleteBreed);
+
+export const restoreBreed = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_restoreBreed);

--- a/app/lib/actions/colors-catalog.actions.ts
+++ b/app/lib/actions/colors-catalog.actions.ts
@@ -1,0 +1,202 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { ColorFormSchema } from "../zod-schemas/color.schemas";
+
+export interface ColorFormState {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    name?: string[];
+  };
+}
+
+// Shared duplicate check: case-insensitive, global, ignores the row being
+// edited (so renaming a color to itself doesn't collide).
+const findDuplicate = async (name: string, excludeId?: string) => {
+  return prisma.color.findFirst({
+    where: {
+      name: { equals: name, mode: "insensitive" },
+      deletedAt: null,
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { id: true },
+  });
+};
+
+const _createColor = async (
+  prevState: ColorFormState,
+  formData: FormData,
+): Promise<ColorFormState> => {
+  const validatedFields = ColorFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create color.",
+    };
+  }
+
+  const { name } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name);
+    if (existing) {
+      return {
+        success: false,
+        message: "A color with that name already exists.",
+      };
+    }
+
+    await prisma.color.create({ data: { name } });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A color with that name already exists.",
+      };
+    }
+    console.error("Database Error creating color:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create color.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Color created successfully." };
+};
+
+const _updateColor = async (
+  colorId: string,
+  prevState: ColorFormState,
+  formData: FormData,
+): Promise<ColorFormState> => {
+  const parsedId = cuidSchema.safeParse(colorId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid color ID format." };
+  }
+
+  const validatedFields = ColorFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update color.",
+    };
+  }
+
+  const { name } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name, parsedId.data);
+    if (existing) {
+      return {
+        success: false,
+        message: "A color with that name already exists.",
+      };
+    }
+
+    await prisma.color.update({
+      where: { id: parsedId.data },
+      data: { name },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A color with that name already exists.",
+      };
+    }
+    console.error("Database Error updating color:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update color.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Color updated successfully." };
+};
+
+const _deleteColor = async (
+  colorId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(colorId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid color ID format." };
+  }
+
+  try {
+    await prisma.color.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: new Date() },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Color deleted successfully." };
+  } catch (error) {
+    console.error("Database Error deleting color:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to delete color.",
+    };
+  }
+};
+
+const _restoreColor = async (
+  colorId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(colorId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid color ID format." };
+  }
+
+  try {
+    await prisma.color.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: null },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Color restored successfully." };
+  } catch (error) {
+    console.error("Database Error restoring color:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to restore color.",
+    };
+  }
+};
+
+export const createColor = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_createColor);
+
+export const updateColor = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_updateColor);
+
+export const deleteColor = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_deleteColor);
+
+export const restoreColor = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_restoreColor);

--- a/app/lib/actions/species-catalog.actions.ts
+++ b/app/lib/actions/species-catalog.actions.ts
@@ -1,0 +1,218 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/app/lib/prisma";
+import { cuidSchema } from "../zod-schemas/common.schemas";
+import { RequirePermission } from "../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { SpeciesFormSchema } from "../zod-schemas/taxonomy.schemas";
+
+export interface SpeciesFormState {
+  success?: boolean;
+  message?: string | null;
+  errors?: {
+    name?: string[];
+  };
+}
+
+const findDuplicate = async (name: string, excludeId?: string) => {
+  return prisma.species.findFirst({
+    where: {
+      name: { equals: name, mode: "insensitive" },
+      deletedAt: null,
+      ...(excludeId ? { NOT: { id: excludeId } } : {}),
+    },
+    select: { id: true },
+  });
+};
+
+const _createSpecies = async (
+  prevState: SpeciesFormState,
+  formData: FormData,
+): Promise<SpeciesFormState> => {
+  const validatedFields = SpeciesFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to create species.",
+    };
+  }
+
+  const { name } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name);
+    if (existing) {
+      return {
+        success: false,
+        message: "A species with that name already exists.",
+      };
+    }
+
+    await prisma.species.create({ data: { name } });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A species with that name already exists.",
+      };
+    }
+    console.error("Database Error creating species:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to create species.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Species created successfully." };
+};
+
+const _updateSpecies = async (
+  speciesId: string,
+  prevState: SpeciesFormState,
+  formData: FormData,
+): Promise<SpeciesFormState> => {
+  const parsedId = cuidSchema.safeParse(speciesId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid species ID format." };
+  }
+
+  const validatedFields = SpeciesFormSchema.safeParse(
+    Object.fromEntries(formData.entries()),
+  );
+
+  if (!validatedFields.success) {
+    return {
+      success: false,
+      errors: z.flattenError(validatedFields.error).fieldErrors,
+      message: "Missing or invalid fields. Failed to update species.",
+    };
+  }
+
+  const { name } = validatedFields.data;
+
+  try {
+    const existing = await findDuplicate(name, parsedId.data);
+    if (existing) {
+      return {
+        success: false,
+        message: "A species with that name already exists.",
+      };
+    }
+
+    await prisma.species.update({
+      where: { id: parsedId.data },
+      data: { name },
+    });
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return {
+        success: false,
+        message: "A species with that name already exists.",
+      };
+    }
+    console.error("Database Error updating species:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to update species.",
+    };
+  }
+
+  revalidatePath("/dashboard/settings/animal-taxonomy");
+  return { success: true, message: "Species updated successfully." };
+};
+
+const _deleteSpecies = async (
+  speciesId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(speciesId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid species ID format." };
+  }
+
+  try {
+    // Block deletion if the species has dependents: any non-deleted breed,
+    // or any animal. Species is a required parent, so removing it would
+    // orphan breeds and break animal records.
+    const [breedCount, animalCount] = await Promise.all([
+      prisma.breed.count({
+        where: { speciesId: parsedId.data, deletedAt: null },
+      }),
+      prisma.animal.count({ where: { speciesId: parsedId.data } }),
+    ]);
+
+    if (breedCount > 0 || animalCount > 0) {
+      return {
+        success: false,
+        message:
+          "This species can't be deleted because it still has breeds or animals associated with it.",
+      };
+    }
+
+    await prisma.species.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: new Date() },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Species deleted successfully." };
+  } catch (error) {
+    console.error("Database Error deleting species:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to delete species.",
+    };
+  }
+};
+
+const _restoreSpecies = async (
+  speciesId: string,
+): Promise<{ success: boolean; message: string }> => {
+  const parsedId = cuidSchema.safeParse(speciesId);
+  if (!parsedId.success) {
+    return { success: false, message: "Invalid species ID format." };
+  }
+
+  try {
+    await prisma.species.update({
+      where: { id: parsedId.data },
+      data: { deletedAt: null },
+    });
+    revalidatePath("/dashboard/settings/animal-taxonomy");
+    return { success: true, message: "Species restored successfully." };
+  } catch (error) {
+    console.error("Database Error restoring species:", error);
+    return {
+      success: false,
+      message: "Database Error: Failed to restore species.",
+    };
+  }
+};
+
+export const createSpecies = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_createSpecies);
+
+export const updateSpecies = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_updateSpecies);
+
+export const deleteSpecies = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_deleteSpecies);
+
+export const restoreSpecies = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_restoreSpecies);

--- a/app/lib/auth/permissions.ts
+++ b/app/lib/auth/permissions.ts
@@ -61,8 +61,7 @@ export const AppPermissions = {
   // Catalog / System Configuration (admins only)
   MANAGE_CHARACTERISTICS_CATALOG: "characteristics_catalog:manage",
   MANAGE_ASSESSMENT_TEMPLATES: "assessment_templates:manage",
-
-  // 
+  MANAGE_ANIMAL_TAXONOMY: "animal_taxonomy:manage",
 } as const;
 
 export type AppPermission =

--- a/app/lib/auth/roles.config.ts
+++ b/app/lib/auth/roles.config.ts
@@ -48,6 +48,7 @@ const adminPermissions: readonly AppPermission[] = [
   AppPermissions.MANAGE_ROLES,
   AppPermissions.MANAGE_CHARACTERISTICS_CATALOG,
   AppPermissions.MANAGE_ASSESSMENT_TEMPLATES,
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
 ] as const;
 
 export const rolePermissions: Record<Role, readonly AppPermission[]> = {

--- a/app/lib/data/animals/animal.data.ts
+++ b/app/lib/data/animals/animal.data.ts
@@ -133,11 +133,18 @@ const _fetchSectionCardsAnimalData = async (
           },
         },
         breeds: {
+          where: {
+            deletedAt: null,
+          },
           select: {
             name: true,
           },
+          
         },
         colors: {
+          where: {
+            deletedAt: null,
+          },
           select: {
             name: true,
           },

--- a/app/lib/data/breeds/breeds-catalog.data.ts
+++ b/app/lib/data/breeds/breeds-catalog.data.ts
@@ -1,0 +1,25 @@
+import { prisma } from "@/app/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { RequirePermission } from "../../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+
+export type BreedWithSpecies = Prisma.BreedGetPayload<{
+  include: { species: { select: { id: true; name: true } } };
+}>;
+
+const _fetchBreedsCatalog = async (): Promise<BreedWithSpecies[]> => {
+  try {
+    // Management view: include soft-deleted rows so admins can restore.
+    return await prisma.breed.findMany({
+      include: { species: { select: { id: true, name: true } } },
+      orderBy: [{ species: { name: "asc" } }, { name: "asc" }],
+    });
+  } catch (error) {
+    console.error("Failed to fetch breeds catalog:", error);
+    throw new Error("Could not fetch breeds.");
+  }
+};
+
+export const fetchBreedsCatalog = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_fetchBreedsCatalog);

--- a/app/lib/data/colors/olors-catalog.data.ts
+++ b/app/lib/data/colors/olors-catalog.data.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@/app/lib/prisma";
+import { Color } from "@prisma/client";
+import { RequirePermission } from "../../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+
+const _fetchColorsCatalog = async (): Promise<Color[]> => {
+  try {
+    // Management view: include soft-deleted rows so admins can restore.
+    return await prisma.color.findMany({
+      orderBy: { name: "asc" },
+    });
+  } catch (error) {
+    console.error("Failed to fetch colors catalog:", error);
+    throw new Error("Could not fetch colors.");
+  }
+};
+
+export const fetchColorsCatalog = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_fetchColorsCatalog);

--- a/app/lib/data/public.data.ts
+++ b/app/lib/data/public.data.ts
@@ -163,11 +163,13 @@ export const fetchPublicPagePetById = async (id: string) => {
           },
         },
         breeds: {
+          where: { deletedAt: null },
           select: {
             name: true,
           },
         },
         colors: {
+          where: { deletedAt: null },
           select: {
             name: true,
           },

--- a/app/lib/data/species/species-catalog.data.ts
+++ b/app/lib/data/species/species-catalog.data.ts
@@ -1,0 +1,20 @@
+import { prisma } from "@/app/lib/prisma";
+import { Species } from "@prisma/client";
+import { RequirePermission } from "../../auth/protected-actions";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+
+const _fetchSpeciesCatalog = async (): Promise<Species[]> => {
+  try {
+    // Include soft-deleted rows so admins can restore.
+    return await prisma.species.findMany({
+      orderBy: { name: "asc" },
+    });
+  } catch (error) {
+    console.error("Failed to fetch species catalog:", error);
+    throw new Error("Could not fetch species.");
+  }
+};
+
+export const fetchSpeciesCatalog = RequirePermission(
+  AppPermissions.MANAGE_ANIMAL_TAXONOMY,
+)(_fetchSpeciesCatalog);

--- a/app/lib/zod-schemas/color.schemas.ts
+++ b/app/lib/zod-schemas/color.schemas.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ColorFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .transform((s) => s.replace(/\s+/g, " "))
+    .pipe(z.string().min(1, "Name is required.").max(50, "Name is too long.")),
+});

--- a/app/lib/zod-schemas/taxonomy.schemas.ts
+++ b/app/lib/zod-schemas/taxonomy.schemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { cuidSchema } from "./common.schemas";
+
+export const SpeciesFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .transform((s) => s.replace(/\s+/g, " "))
+    .pipe(z.string().min(1, "Name is required.").max(50, "Name is too long.")),
+});
+
+export const BreedFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .transform((s) => s.replace(/\s+/g, " "))
+    .pipe(z.string().min(1, "Name is required.").max(50, "Name is too long.")),
+  speciesId: cuidSchema,
+});

--- a/components/dashboard/settings/animal-taxonomy/breed-form.tsx
+++ b/components/dashboard/settings/animal-taxonomy/breed-form.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Breed, Species } from "@prisma/client";
+import {
+  BreedFormState,
+  createBreed,
+  updateBreed,
+} from "@/app/lib/actions/breeds-catalog.actions";
+import { BreedFormSchema } from "@/app/lib/zod-schemas/taxonomy.schemas";
+import { toast } from "sonner";
+
+const INITIAL_FORM_STATE: BreedFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type BreedFormValues = z.infer<typeof BreedFormSchema>;
+
+interface Props {
+  onFormSubmit: () => void;
+  species: Species[]; // active species, for the selector
+  breed?: Breed;
+}
+
+export const BreedForm = ({ onFormSubmit, species, breed }: Props) => {
+  const action = breed ? updateBreed.bind(null, breed.id) : createBreed;
+
+  const [state, formAction, isPending] = useActionState<
+    BreedFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<BreedFormValues>({
+    resolver: zodResolver(BreedFormSchema),
+    defaultValues: breed
+      ? { name: breed.name, speciesId: breed.speciesId }
+      : { name: "", speciesId: "" },
+  });
+
+  useEffect(() => {
+    if (!state.message) return;
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof BreedFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: BreedFormValues) => {
+    const formData = new FormData();
+    formData.append("name", data.name);
+    formData.append("speciesId", data.speciesId);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <div className="grid grid-cols-1 gap-4">
+          {/* Species */}
+          <FormField
+            control={form.control}
+            name="speciesId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="speciesId">Species</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  name={field.name}
+                >
+                  <FormControl>
+                    <SelectTrigger className="w-full" id="speciesId">
+                      <SelectValue placeholder="Select a species" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {species.map((s) => (
+                      <SelectItem key={s.id} value={s.id}>
+                        {s.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Name */}
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel htmlFor="name">Name</FormLabel>
+                <FormControl>
+                  <Input id="name" placeholder="e.g. Labrador" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {breed ? "Updating..." : "Creating..."}
+              </>
+            ) : breed ? (
+              "Update Breed"
+            ) : (
+              "Create Breed"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/settings/animal-taxonomy/breeds-section.tsx
+++ b/components/dashboard/settings/animal-taxonomy/breeds-section.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { clsx } from "clsx";
+import { MoreHorizontal, PlusCircle } from "lucide-react";
+import { Species } from "@prisma/client";
+import { BreedWithSpecies } from "@/app/lib/data/breeds/breeds-catalog.data";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { BreedForm } from "./breed-form";
+import {
+  deleteBreed,
+  restoreBreed,
+} from "@/app/lib/actions/breeds-catalog.actions";
+import { toast } from "sonner";
+
+function BreedActions({
+  breed,
+  species,
+}: {
+  breed: BreedWithSpecies;
+  species: Species[];
+}) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deleteBreed(breed.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message, {
+            action: { label: "Undo", onClick: () => onRestore() },
+          });
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restoreBreed(breed.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message);
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {breed.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Edit Breed</DialogTitle>
+          <DialogDescription>
+            Update the name or species for this breed. Click update when
+            you&apos;re done.
+          </DialogDescription>
+        </DialogHeader>
+        <BreedForm
+          onFormSubmit={() => setIsDialogOpen(false)}
+          species={species}
+          breed={breed}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface Props {
+  breeds: BreedWithSpecies[];
+  species: Species[];
+}
+
+export const BreedsSection = ({ breeds, species }: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  // Only active species can receive new breeds.
+  const activeSpecies = species.filter((s) => !s.deletedAt);
+
+  // Group breeds by species name (data arrives pre-sorted from the fetcher).
+  const grouped = breeds.reduce<Record<string, BreedWithSpecies[]>>(
+    (acc, breed) => {
+      const key = breed.species.name;
+      (acc[key] = acc[key] || []).push(breed);
+      return acc;
+    },
+    {},
+  );
+  const speciesNames = Object.keys(grouped);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle className="@[650px]/card:text-xl">Breeds</CardTitle>
+        <CardDescription>
+          Manage the breeds available within each species.
+        </CardDescription>
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm" disabled={activeSpecies.length === 0}>
+                <PlusCircle className="size-4 mr-2" />
+                Add Breed
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[480px]">
+              <DialogHeader>
+                <DialogTitle>Add Breed</DialogTitle>
+                <DialogDescription>
+                  Create a new breed under a species. Click create when
+                  you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <BreedForm
+                onFormSubmit={() => setIsAddDialogOpen(false)}
+                species={activeSpecies}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {breeds.length > 0 ? (
+          <div className="space-y-4">
+            {speciesNames.map((name) => (
+              <div key={name} className="border rounded-lg p-4 bg-card">
+                <h4 className="font-medium mb-3 text-foreground">{name}</h4>
+                <div className="flex flex-wrap gap-2">
+                  {grouped[name].map((breed) => (
+                    <div
+                      key={breed.id}
+                      className={clsx(
+                        "flex items-center gap-1 rounded-md border pl-2.5 pr-1 py-0.5",
+                        breed.deletedAt && "opacity-50 border-dashed",
+                      )}
+                    >
+                      <span className="text-sm font-medium">{breed.name}</span>
+                      {breed.deletedAt && (
+                        <Badge
+                          variant="destructive"
+                          className="ml-1 text-[10px] px-1 py-0"
+                        >
+                          Deleted
+                        </Badge>
+                      )}
+                      <BreedActions breed={breed} species={activeSpecies} />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 px-4 border-2 border-dashed rounded-lg">
+            <p className="text-muted-foreground text-sm">
+              {activeSpecies.length === 0
+                ? "Create a species first before adding breeds."
+                : "No breeds have been created yet."}
+            </p>
+            {activeSpecies.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-4"
+                onClick={() => setIsAddDialogOpen(true)}
+              >
+                <PlusCircle className="size-4 mr-2" />
+                Add Breed
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/components/dashboard/settings/animal-taxonomy/color-actions.tsx
+++ b/components/dashboard/settings/animal-taxonomy/color-actions.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Color } from "@prisma/client";
+import { ColorForm } from "./color-form";
+import {
+  deleteColor,
+  restoreColor,
+} from "@/app/lib/actions/colors-catalog.actions";
+import { toast } from "sonner";
+
+interface Props {
+  color: Color;
+}
+
+export function ColorActions({ color }: Props) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deleteColor(color.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message, {
+            action: {
+              label: "Undo",
+              onClick: () => onRestore(),
+            },
+          });
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restoreColor(color.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message);
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {color.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Edit Color</DialogTitle>
+          <DialogDescription>
+            Update the name for this color. Click update when you&apos;re done.
+          </DialogDescription>
+        </DialogHeader>
+        <ColorForm onFormSubmit={() => setIsDialogOpen(false)} color={color} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/dashboard/settings/animal-taxonomy/color-form.tsx
+++ b/components/dashboard/settings/animal-taxonomy/color-form.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Color } from "@prisma/client";
+import {
+  ColorFormState,
+  createColor,
+  updateColor,
+} from "@/app/lib/actions/colors-catalog.actions";
+import { ColorFormSchema } from "@/app/lib/zod-schemas/color.schemas";
+import { toast } from "sonner";
+
+const INITIAL_FORM_STATE: ColorFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type ColorFormValues = z.infer<typeof ColorFormSchema>;
+
+interface Props {
+  onFormSubmit: () => void;
+  color?: Color;
+}
+
+export const ColorForm = ({ onFormSubmit, color }: Props) => {
+  const action = color ? updateColor.bind(null, color.id) : createColor;
+
+  const [state, formAction, isPending] = useActionState<
+    ColorFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<ColorFormValues>({
+    resolver: zodResolver(ColorFormSchema),
+    defaultValues: color ? { name: color.name } : { name: "" },
+  });
+
+  useEffect(() => {
+    if (!state.message) {
+      return;
+    }
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof ColorFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: ColorFormValues) => {
+    const formData = new FormData();
+    formData.append("name", data.name);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="name">Name</FormLabel>
+              <FormControl>
+                <Input id="name" placeholder="e.g. Brindle" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {color ? "Updating..." : "Creating..."}
+              </>
+            ) : color ? (
+              "Update Color"
+            ) : (
+              "Create Color"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/settings/animal-taxonomy/colors-section.tsx
+++ b/components/dashboard/settings/animal-taxonomy/colors-section.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { Color } from "@prisma/client";
+import { clsx } from "clsx";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { PlusCircle } from "lucide-react";
+import { ColorForm } from "./color-form";
+import { ColorActions } from "./color-actions";
+
+interface Props {
+  colors: Color[];
+}
+
+export const ColorsSection = ({ colors }: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle className="@[650px]/card:text-xl">Colors</CardTitle>
+        <CardDescription>
+          Manage the colors used to describe animals&apos; coats and markings.
+        </CardDescription>
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <PlusCircle className="size-4 mr-2" />
+                Add Color
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[480px]">
+              <DialogHeader>
+                <DialogTitle>Add Color</DialogTitle>
+                <DialogDescription>
+                  Create a new color for the catalog. Click create when
+                  you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <ColorForm onFormSubmit={() => setIsAddDialogOpen(false)} />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {colors.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {colors.map((color) => (
+              <div
+                key={color.id}
+                className={clsx(
+                  "flex items-center gap-1 rounded-md border pl-2.5 pr-1 py-0.5",
+                  color.deletedAt && "opacity-50 border-dashed",
+                )}
+              >
+                <span className="text-sm font-medium">{color.name}</span>
+                {color.deletedAt && (
+                  <Badge
+                    variant="destructive"
+                    className="ml-1 text-[10px] px-1 py-0"
+                  >
+                    Deleted
+                  </Badge>
+                )}
+                <ColorActions color={color} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 px-4 border-2 border-dashed rounded-lg">
+            <p className="text-muted-foreground text-sm">
+              No colors have been created yet.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-4"
+              onClick={() => setIsAddDialogOpen(true)}
+            >
+              <PlusCircle className="size-4 mr-2" />
+              Add Color
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/components/dashboard/settings/animal-taxonomy/species-form.tsx
+++ b/components/dashboard/settings/animal-taxonomy/species-form.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { startTransition, useActionState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import { Species } from "@prisma/client";
+import {
+  SpeciesFormState,
+  createSpecies,
+  updateSpecies,
+} from "@/app/lib/actions/species-catalog.actions";
+import { SpeciesFormSchema } from "@/app/lib/zod-schemas/taxonomy.schemas";
+import { toast } from "sonner";
+
+const INITIAL_FORM_STATE: SpeciesFormState = {
+  success: false,
+  message: null,
+  errors: {},
+};
+
+type SpeciesFormValues = z.infer<typeof SpeciesFormSchema>;
+
+interface Props {
+  onFormSubmit: () => void;
+  species?: Species;
+}
+
+export const SpeciesForm = ({ onFormSubmit, species }: Props) => {
+  const action = species ? updateSpecies.bind(null, species.id) : createSpecies;
+
+  const [state, formAction, isPending] = useActionState<
+    SpeciesFormState,
+    FormData
+  >(action, INITIAL_FORM_STATE);
+
+  const form = useForm<SpeciesFormValues>({
+    resolver: zodResolver(SpeciesFormSchema),
+    defaultValues: species ? { name: species.name } : { name: "" },
+  });
+
+  useEffect(() => {
+    if (!state.message) return;
+
+    if (state.success) {
+      toast.success(state.message);
+      onFormSubmit();
+    } else if (state.errors) {
+      toast.error(state.message || "Please check the form for errors.");
+      for (const [key, value] of Object.entries(state.errors)) {
+        form.setError(key as keyof SpeciesFormValues, {
+          type: "server",
+          message: value?.join(", "),
+        });
+      }
+    } else {
+      toast.error(state.message);
+    }
+  }, [state, form, onFormSubmit]);
+
+  const onSubmit = (data: SpeciesFormValues) => {
+    const formData = new FormData();
+    formData.append("name", data.name);
+
+    startTransition(() => {
+      formAction(formData);
+    });
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel htmlFor="name">Name</FormLabel>
+              <FormControl>
+                <Input id="name" placeholder="e.g. Dog" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="button" variant="outline" disabled={isPending}>
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {species ? "Updating..." : "Creating..."}
+              </>
+            ) : species ? (
+              "Update Species"
+            ) : (
+              "Create Species"
+            )}
+          </Button>
+        </DialogFooter>
+      </form>
+    </Form>
+  );
+};

--- a/components/dashboard/settings/animal-taxonomy/species-section.tsx
+++ b/components/dashboard/settings/animal-taxonomy/species-section.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { clsx } from "clsx";
+import { MoreHorizontal, PlusCircle } from "lucide-react";
+import { Species } from "@prisma/client";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SpeciesForm } from "./species-form";
+import {
+  deleteSpecies,
+  restoreSpecies,
+} from "@/app/lib/actions/species-catalog.actions";
+import { toast } from "sonner";
+
+function SpeciesActions({ species }: { species: Species }) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const onSoftDelete = () => {
+    startTransition(() => {
+      deleteSpecies(species.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message, {
+            action: { label: "Undo", onClick: () => onRestore() },
+          });
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  const onRestore = () => {
+    startTransition(() => {
+      restoreSpecies(species.id).then((data) => {
+        if (data?.success) {
+          toast.success(data.message);
+        } else if (data?.message) {
+          toast.error(data.message);
+        }
+      });
+    });
+  };
+
+  return (
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-7 w-7">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DialogTrigger asChild>
+            <DropdownMenuItem>Edit</DropdownMenuItem>
+          </DialogTrigger>
+          {species.deletedAt ? (
+            <DropdownMenuItem onClick={onRestore} disabled={isPending}>
+              Restore
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={onSoftDelete}
+              disabled={isPending}
+            >
+              Delete
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Edit Species</DialogTitle>
+          <DialogDescription>
+            Update the name for this species. Click update when you&apos;re
+            done.
+          </DialogDescription>
+        </DialogHeader>
+        <SpeciesForm
+          onFormSubmit={() => setIsDialogOpen(false)}
+          species={species}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface Props {
+  species: Species[];
+}
+
+export const SpeciesSection = ({ species }: Props) => {
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+
+  return (
+    <Card className="@container/card">
+      <CardHeader>
+        <CardTitle className="@[650px]/card:text-xl">Species</CardTitle>
+        <CardDescription>
+          Manage the species of animals your shelter handles.
+        </CardDescription>
+        <CardAction>
+          <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <PlusCircle className="size-4 mr-2" />
+                Add Species
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[480px]">
+              <DialogHeader>
+                <DialogTitle>Add Species</DialogTitle>
+                <DialogDescription>
+                  Create a new species. Click create when you&apos;re done.
+                </DialogDescription>
+              </DialogHeader>
+              <SpeciesForm onFormSubmit={() => setIsAddDialogOpen(false)} />
+            </DialogContent>
+          </Dialog>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        {species.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {species.map((s) => (
+              <div
+                key={s.id}
+                className={clsx(
+                  "flex items-center gap-1 rounded-md border pl-2.5 pr-1 py-0.5",
+                  s.deletedAt && "opacity-50 border-dashed",
+                )}
+              >
+                <span className="text-sm font-medium">{s.name}</span>
+                {s.deletedAt && (
+                  <Badge
+                    variant="destructive"
+                    className="ml-1 text-[10px] px-1 py-0"
+                  >
+                    Deleted
+                  </Badge>
+                )}
+                <SpeciesActions species={s} />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8 px-4 border-2 border-dashed rounded-lg">
+            <p className="text-muted-foreground text-sm">
+              No species have been created yet.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-4"
+              onClick={() => setIsAddDialogOpen(true)}
+            >
+              <PlusCircle className="size-4 mr-2" />
+              Add Species
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/prisma/migrations/20260624212740_species_name_unique/migration.sql
+++ b/prisma/migrations/20260624212740_species_name_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `species` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "species_name_key" ON "species"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -332,7 +332,7 @@ model Animal {
 
 model Species {
   id      String   @id @default(cuid())
-  name    String
+  name    String   @unique
   animals Animal[]
   breeds  Breed[] // A species can have many breeds
 


### PR DESCRIPTION
## What
Adds an admin-only Animal Taxonomy section under Settings for managing the species, breeds, and colors used to describe animals.

## Changes
- New page at `/dashboard/settings/animal-taxonomy` with Species, Breeds, and Colors sections
- Full CRUD for all three: create, rename, soft-delete, restore
- New `MANAGE_ANIMAL_TAXONOMY` permission (admin-only), enforced server-side on every action
- Settings index card + nav entry for Animal Taxonomy

### Rules enforced
- Species names globally unique; colors globally unique; breeds unique per species (`@@unique([name, speciesId])`)
- Case-insensitive duplicate checks + whitespace normalization (casing preserved), consistent with characteristics
- **Species deletion blocked** if it has any non-deleted breeds or any animals (required structural parent)
- **Breeds and colors soft-delete freely** — consumption views filter them out
- Breeds require an active species; the breed form only offers non-deleted species, and the action re-validates server-side

### Consumption filtering
- Current-state views (public pet page, dashboard animal card) filter `deletedAt: null` on breeds/colors
- Historical records (adoption applications, outcomes) intentionally NOT filtered, they show taxonomy as recorded, and reference the animal live by design

## Migration
- Adds `@unique` to `Species.name`
- Deploy note: run `prisma migrate deploy`. Resolve any duplicate species names in prod data **before** deploying, or the constraint will fail to apply.