### PR TITLE
Support multiple colors per animal with a designated primary color

### DIFF
--- a/app/(publicpages)/pets/[id]/page.tsx
+++ b/app/(publicpages)/pets/[id]/page.tsx
@@ -44,7 +44,14 @@ const Page = async ({ params }: Props) => {
   // Prepare array data for display
   const breedString =
     animal.breeds?.map((b) => b.name).join(", ") || "Mixed Breed";
-  const colorString = animal.colors?.map((c) => c.name).join(", ") || "";
+
+  // Primary color shown on its own; remaining colors listed separately.
+  const primaryColorName = animal.primaryColor?.name || "";
+  const additionalColorString =
+    animal.colors
+      ?.filter((c) => c.name !== animal.primaryColor?.name)
+      .map((c) => c.name)
+      .join(", ") || "";
 
   const adoptCta =
     animal.listingStatus === "PENDING_ADOPTION" ? (
@@ -104,7 +111,8 @@ const Page = async ({ params }: Props) => {
           <PetCardDetail label="Sex" value={animal.sex} />
           <PetCardDetail label="Breed" value={breedString} />
           <PetCardDetail label="Size" value={animal.size} />
-          <PetCardDetail label="Color" value={colorString} />
+          <PetCardDetail label="Primary Color" value={primaryColorName} />
+          <PetCardDetail label="Other Colors" value={additionalColorString} />
           <PetCardDetail
             label="Spayed/Neutered"
             value={animal.isSpayedNeutered ? "Yes" : "No"}

--- a/app/api/reset-demo/route.ts
+++ b/app/api/reset-demo/route.ts
@@ -18,49 +18,16 @@ export async function GET(request: Request) {
   }
 
   try {
-    console.log("Starting demo database reset...");
-
-    // Delete deep relation/junction records & logs first
-    await prisma.animalActivityLog.deleteMany({});
-    await prisma.templateField.deleteMany({});
-    await prisma.medicalRecord.deleteMany({});
-    await prisma.animalNote.deleteMany({});
-    await prisma.task.deleteMany({});
-    await prisma.assessment.deleteMany({});
-    
-    // Delete operational records that link animals, people, and templates
-    await prisma.outcome.deleteMany({});
-    await prisma.intake.deleteMany({});
-    await prisma.animalImage.deleteMany({});
-    await prisma.assessmentTemplate.deleteMany({});
-
-    // Delete core entities that were referenced by the operational records above
-    await prisma.user.deleteMany({});
-    await prisma.person.deleteMany({});
-    await prisma.animal.deleteMany({});
-    await prisma.partner.deleteMany({});
-
-    // Delete master configuration/lookup tables last
-    await prisma.characteristic.deleteMany({});
-    await prisma.color.deleteMany({});
-    await prisma.breed.deleteMany({});
-    await prisma.species.deleteMany({});
-
-    console.log("Database wiped.");
-
-    // Run full seeding logic
-    console.log("Seeding new data...");
+    console.log("Starting demo database reset via seed script...");
     await main();
-    console.log("Database has been successfully re-seeded.");
+    console.log("Database has been successfully cleared and re-seeded.");
 
     return NextResponse.json({
       success: true,
       message: "Demo database reset successfully.",
     });
   } catch (error) {
-    // Log the detailed error on the server
     console.error("Failed to reset demo database:", error);
-    // Return a generic error message to the client
     return NextResponse.json(
       { success: false, error: "Internal Server Error" },
       { status: 500 }

--- a/app/lib/actions/animal.actions.ts
+++ b/app/lib/actions/animal.actions.ts
@@ -20,10 +20,10 @@ import {
   IntakeType,
 } from "@prisma/client";
 import { getAnimalSize } from "../utils/animal-size";
-
 import { ConflictError, NotFoundError } from "../utils/errors";
 import { del } from "@vercel/blob";
 import { isDemo } from "@/lib/flags";
+
 const _createAnimal = async (
   user: SessionUser,
   prevState: AnimalFormState,
@@ -38,9 +38,14 @@ const _createAnimal = async (
     };
   }
 
-  const validatedFields = AnimalFormSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  // Array fields must be pulled with getAll — Object.fromEntries keeps only
+  // the last value for repeated keys.
+  const additionalColors = formData.getAll("additionalColors");
+
+  const validatedFields = AnimalFormSchema.safeParse({
+    ...Object.fromEntries(formData.entries()),
+    additionalColors,
+  });
 
   if (!validatedFields.success) {
     return {
@@ -67,6 +72,7 @@ const _createAnimal = async (
     species: speciesId,
     breed: breedId,
     primaryColor: primaryColorId,
+    additionalColors: additionalColorIds,
     intakeType,
     intakeDate,
     notes,
@@ -80,6 +86,12 @@ const _createAnimal = async (
     heightCm,
   } = validatedFields.data;
 
+  // Full color set = primary + additionals, de-duped in case the primary
+  // also appears in the additional list.
+  const allColorIds = Array.from(
+    new Set([primaryColorId, ...additionalColorIds]),
+  );
+
   try {
     await prisma.$transaction(async (tx) => {
       const speciesRecord = await tx.species.findUnique({
@@ -89,6 +101,14 @@ const _createAnimal = async (
 
       if (!speciesRecord) {
         throw new Error("Invalid Species ID provided.");
+      }
+
+      // Guard: all submitted colors must exist and not be soft-deleted.
+      const validColorCount = await tx.color.count({
+        where: { id: { in: allColorIds }, deletedAt: null },
+      });
+      if (validColorCount !== allColorIds.length) {
+        throw new Error("One or more selected colors are no longer available.");
       }
 
       const calculatedSize = getAnimalSize(
@@ -128,7 +148,8 @@ const _createAnimal = async (
           state: validatedFields.data.foundState || null,
           species: { connect: { id: speciesId } },
           breeds: { connect: { id: breedId } },
-          colors: { connect: { id: primaryColorId } },
+          colors: { connect: allColorIds.map((id) => ({ id })) },
+          primaryColor: { connect: { id: primaryColorId } },
         },
       });
 
@@ -199,9 +220,14 @@ const _updateAnimal = async (
   const validatedAnimalId = parsedId.data;
   const staffMemberId = user.personId;
 
-  const validatedFields = AnimalFormSchema.safeParse(
-    Object.fromEntries(formData.entries())
-  );
+  // Array fields must be pulled with getAll — Object.fromEntries keeps only
+  // the last value for repeated keys.
+  const additionalColors = formData.getAll("additionalColors");
+
+  const validatedFields = AnimalFormSchema.safeParse({
+    ...Object.fromEntries(formData.entries()),
+    additionalColors,
+  });
 
   if (!validatedFields.success) {
     return {
@@ -221,6 +247,7 @@ const _updateAnimal = async (
     species: speciesId,
     breed: breedId,
     primaryColor: primaryColorId,
+    additionalColors: additionalColorIds,
     weightKg,
     heightCm,
     city,
@@ -240,6 +267,12 @@ const _updateAnimal = async (
 
   const numericWeight = weightKg === "" ? undefined : weightKg;
   const numericHeight = heightCm === "" ? undefined : heightCm;
+
+  // Full color set = primary + additionals, de-duped in case the primary
+  // also appears in the additional list.
+  const allColorIds = Array.from(
+    new Set([primaryColorId, ...additionalColorIds]),
+  );
 
   try {
     await prisma.$transaction(async (tx) => {
@@ -289,6 +322,16 @@ const _updateAnimal = async (
         throw new NotFoundError("The specified species does not exist.");
       }
 
+      // Guard: all submitted colors must exist and not be soft-deleted.
+      const validColorCount = await tx.color.count({
+        where: { id: { in: allColorIds }, deletedAt: null },
+      });
+      if (validColorCount !== allColorIds.length) {
+        throw new ConflictError(
+          "One or more selected colors are no longer available. Please refresh and try again.",
+        );
+      }
+
       const calculatedSize = getAnimalSize(
         speciesRecord.name,
         numericWeight as number | null
@@ -304,7 +347,6 @@ const _updateAnimal = async (
 
       await tx.animal.update({
         where: { id: validatedAnimalId },
-
         data: {
           name: animalName,
           birthDate: estimatedBirthDate,
@@ -321,7 +363,8 @@ const _updateAnimal = async (
           state: state,
           species: { connect: { id: speciesId } },
           breeds: { set: [{ id: breedId }] },
-          colors: { set: [{ id: primaryColorId }] },
+          colors: { set: allColorIds.map((id) => ({ id })) },
+          primaryColor: { connect: { id: primaryColorId } },
         },
       });
 
@@ -338,7 +381,7 @@ const _updateAnimal = async (
     });
   } catch (error) {
     console.error("Database Error updating animal:", error);
-    if (error instanceof ConflictError) {
+    if (error instanceof ConflictError || error instanceof NotFoundError) {
       return { message: error.message };
     }
     return {

--- a/app/lib/data/animals/animal.data.ts
+++ b/app/lib/data/animals/animal.data.ts
@@ -26,7 +26,7 @@ const _fetchAnimals = async (
   sexInput: string | undefined,
   pageSizeInput: number,
   sortInput: string | undefined
-): Promise<{ animals: AnimalsPayload[]; totalPages: number; totalRows: number}> => {
+): Promise<{ animals: AnimalsPayload[]; totalPages: number; totalRows: number }> => {
   // Parse the query and currentPage
   const validatedArgs = DashboardAnimalsSchema.safeParse({
     query: queryInput,
@@ -84,7 +84,7 @@ const _fetchAnimals = async (
 
     const totalPages = Math.ceil(totalCount / pageSize);
 
-    return { animals, totalPages, totalRows: totalCount};
+    return { animals, totalPages, totalRows: totalCount };
   } catch (error) {
     console.error("Error fetching animals.", error);
     throw new Error("Error fetching animals.");
@@ -139,7 +139,11 @@ const _fetchSectionCardsAnimalData = async (
           select: {
             name: true,
           },
-          
+        },
+        primaryColor: {
+          select: {
+            name: true,
+          },
         },
         colors: {
           where: {
@@ -148,7 +152,6 @@ const _fetchSectionCardsAnimalData = async (
           select: {
             name: true,
           },
-          take: 1,
         },
         adoptionApplications: {
           select: {
@@ -214,6 +217,7 @@ const _fetchAnimalById = async (
         microchipNumber: true,
         healthStatus: true,
         speciesId: true,
+        primaryColorId: true,
         breeds: {
           select: {
             id: true,

--- a/app/lib/data/public.data.ts
+++ b/app/lib/data/public.data.ts
@@ -168,6 +168,11 @@ export const fetchPublicPagePetById = async (id: string) => {
             name: true,
           },
         },
+        primaryColor: {
+          select: {
+            name: true,
+          },
+        },
         colors: {
           where: { deletedAt: null },
           select: {

--- a/app/lib/form-state-types.ts
+++ b/app/lib/form-state-types.ts
@@ -8,12 +8,12 @@ export type AnimalFormState = {
     species?: string[];
     breed?: string[];
     primaryColor?: string[];
+    additionalColors?: string[];
     sex?: string[];
     size?: string[];
     estimatedBirthDate?: string[];
     healthStatus?: string[];
     microchipNumber?: string[];
-
     intakeType?: string[];
     intakeDate?: string[];
     sourcePartnerId?: string[];
@@ -22,7 +22,6 @@ export type AnimalFormState = {
     foundState?: string[];
     surrenderingPersonName?: string[];
     surrenderingPersonPhone?: string[];
-    
     notes?: string[];
   };
 };

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -73,9 +73,11 @@ export type AnimalSectionCardPayload = Prisma.AnimalGetPayload<{
     breeds: {
       select: { name: true };
     };
+    primaryColor: {
+      select: { name: true };
+    };
     colors: {
       select: { name: true };
-      take: 1;
     };
     adoptionApplications: {
       select: { status: true };
@@ -113,6 +115,7 @@ export type AnimalIntakeFormPayload = Prisma.AnimalGetPayload<{
     microchipNumber: true;
     healthStatus: true;
     speciesId: true;
+    primaryColorId: true;
     breeds: {
       select: {
         id: true;

--- a/app/lib/zod-schemas/animal.schemas.ts
+++ b/app/lib/zod-schemas/animal.schemas.ts
@@ -84,6 +84,10 @@ export const AnimalFormSchema = z
     primaryColor: z.cuid2({
       error: "A valid primary color ID is required.",
     }),
+    additionalColors: z
+      .array(z.cuid2({ error: "A valid color ID is required." }))
+      .optional()
+      .default([]),
     sex: z.enum(Sex, {
       error: (issue) =>
         issue.input === undefined ? "Sex is required." : undefined,
@@ -144,6 +148,14 @@ export const AnimalFormSchema = z
         code: "custom",
         message: "Source partner is required for transfers.",
         path: ["sourcePartnerId"],
+      });
+    }
+
+    if (data.additionalColors.includes(data.primaryColor)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "The primary color shouldn't be repeated in additional colors.",
+        path: ["additionalColors"],
       });
     }
 

--- a/components/dashboard/animals/animal-intake-form.tsx
+++ b/components/dashboard/animals/animal-intake-form.tsx
@@ -16,7 +16,13 @@ import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { Control, FieldValues, useForm, UseFormWatch } from "react-hook-form";
 import { z } from "zod";
 import { format } from "date-fns";
-import { Calendar as CalendarIcon, Loader2 } from "lucide-react";
+import {
+  Calendar as CalendarIcon,
+  Check,
+  ChevronsUpDown,
+  Loader2,
+  X,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -43,6 +49,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
 import {
   Form,
   FormControl,
@@ -129,7 +144,10 @@ const AnimalForm = ({
           animalName: animal.name,
           species: animal.speciesId,
           breed: animal.breeds[0]?.id || "",
-          primaryColor: animal.colors[0]?.id || "",
+          primaryColor: animal.primaryColorId || "",
+          additionalColors: animal.colors
+            .filter((c) => c.id !== animal.primaryColorId)
+            .map((c) => c.id),
           sex: animal.sex,
           estimatedBirthDate: new Date(animal.birthDate),
           weightKg: animal.weightKg ?? "",
@@ -153,6 +171,7 @@ const AnimalForm = ({
           sex: animalSexOptions[0].value,
           breed: "",
           primaryColor: "",
+          additionalColors: [],
           weightKg: "",
           heightCm: "",
           microchipNumber: "",
@@ -186,7 +205,12 @@ const AnimalForm = ({
   const onSubmit = (data: AnimalFormValues) => {
     const formData = new FormData();
     for (const [key, value] of Object.entries(data)) {
-      if (value instanceof Date) {
+      if (key === "additionalColors") {
+        // Append each id separately so formData.getAll() works server-side.
+        (value as string[] | undefined)?.forEach((id) =>
+          formData.append("additionalColors", id),
+        );
+      } else if (value instanceof Date) {
         formData.append(key, value.toISOString());
       } else if (value != null && value !== "") {
         formData.append(key, String(value));
@@ -322,6 +346,101 @@ const AnimalForm = ({
                       <FormMessage />
                     </FormItem>
                   )}
+                />
+                <FormField
+                  control={form.control}
+                  name="additionalColors"
+                  render={({ field }) => {
+                    const primaryColorId = form.watch("primaryColor");
+                    const selectedIds: string[] = field.value || [];
+                    // Options exclude the currently-selected primary color.
+                    const available = colors.filter(
+                      (c) => c.id !== primaryColorId,
+                    );
+                    const toggle = (id: string) => {
+                      if (selectedIds.includes(id)) {
+                        field.onChange(selectedIds.filter((x) => x !== id));
+                      } else {
+                        field.onChange([...selectedIds, id]);
+                      }
+                    };
+                    return (
+                      <FormItem className="col-span-2 flex flex-col">
+                        <FormLabel>Additional Colors</FormLabel>
+                        <Popover>
+                          <PopoverTrigger asChild>
+                            <FormControl>
+                              <Button
+                                variant="outline"
+                                role="combobox"
+                                className="w-full justify-between font-normal"
+                              >
+                                {selectedIds.length > 0
+                                  ? `${selectedIds.length} selected`
+                                  : "Select colors"}
+                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                              </Button>
+                            </FormControl>
+                          </PopoverTrigger>
+                          <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
+                            <Command>
+                              <CommandInput placeholder="Search colors..." />
+                              <CommandList>
+                                <CommandEmpty>No color found.</CommandEmpty>
+                                <CommandGroup>
+                                  {available.map((c) => {
+                                    const checked = selectedIds.includes(c.id);
+                                    return (
+                                      <CommandItem
+                                        key={c.id}
+                                        value={c.name}
+                                        onSelect={() => toggle(c.id)}
+                                      >
+                                        <Check
+                                          className={cn(
+                                            "mr-2 h-4 w-4",
+                                            checked
+                                              ? "opacity-100"
+                                              : "opacity-0",
+                                          )}
+                                        />
+                                        {c.name}
+                                      </CommandItem>
+                                    );
+                                  })}
+                                </CommandGroup>
+                              </CommandList>
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                        {selectedIds.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-2">
+                            {selectedIds.map((id) => {
+                              const color = colors.find((c) => c.id === id);
+                              if (!color) return null;
+                              return (
+                                <Badge
+                                  key={id}
+                                  variant="secondary"
+                                  className="gap-1"
+                                >
+                                  {color.name}
+                                  <button
+                                    type="button"
+                                    onClick={() => toggle(id)}
+                                    className="rounded-full hover:bg-black/10 dark:hover:bg-white/10"
+                                  >
+                                    <X className="h-3 w-3" />
+                                  </button>
+                                </Badge>
+                              );
+                            })}
+                          </div>
+                        )}
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
                 />
                 <FormField
                   control={form.control}
@@ -592,12 +711,6 @@ const AnimalForm = ({
 
             {/* Intake Section - Only show on CREATE mode */}
             {!isEditMode && (
-              // <IntakeFormFields
-              //   control={form.control}
-              //   watch={form.watch}
-              //   partners={partners}
-              //   isEditMode={false}
-              // />
               <IntakeFormFields
                 control={
                   form.control as unknown as Control<

--- a/components/dashboard/animals/animal-section-cards.tsx
+++ b/components/dashboard/animals/animal-section-cards.tsx
@@ -84,7 +84,7 @@ const AnimalSectionCards = async ({ params }: Props) => {
 
     const config =
       HEALTH_STATUS_ALERTS[
-        animal.healthStatus as keyof typeof HEALTH_STATUS_ALERTS
+      animal.healthStatus as keyof typeof HEALTH_STATUS_ALERTS
       ];
     if (!config) return null;
 
@@ -319,9 +319,24 @@ const AnimalSectionCards = async ({ params }: Props) => {
               <div className="flex items-center justify-between border-b pb-2 text-sm">
                 <span className="text-muted-foreground">Primary Color</span>
                 <span className="font-medium">
-                  {animal.colors[0]?.name || "N/A"}
+                  {animal.primaryColor?.name || "N/A"}
                 </span>
               </div>
+              {(() => {
+                const additional = animal.colors.filter(
+                  (c) => c.name !== animal.primaryColor?.name,
+                );
+                return additional.length > 0 ? (
+                  <div className="flex items-center justify-between border-b pb-2 text-sm">
+                    <span className="text-muted-foreground">
+                      Other Colors
+                    </span>
+                    <span className="font-medium text-right">
+                      {additional.map((c) => c.name).join(", ")}
+                    </span>
+                  </div>
+                ) : null;
+              })()}
             </div>
           </div>
 

--- a/components/public-pages/nav/top-nav.tsx
+++ b/components/public-pages/nav/top-nav.tsx
@@ -46,7 +46,7 @@ const TopNav = ({ userImage, showUserProfile, links }: TopNavProps) => {
                   className="text-gray-400 hover:bg-gray-700 hover:text-white"
                 >
                   <span className="sr-only">Open main menu</span>
-                  <Bars3Icon className="block h-6 w-6" aria-hidden="true" />
+                  <Bars3Icon className="block size-6" aria-hidden="true" />
                 </Button>
               </SheetTrigger>
               <SheetContent

--- a/prisma/migrations/20260625225440_add_primary_color/migration.sql
+++ b/prisma/migrations/20260625225440_add_primary_color/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `primary_color_id` to the `animals` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "animals" ADD COLUMN     "primary_color_id" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "animals" ADD CONSTRAINT "animals_primary_color_id_fkey" FOREIGN KEY ("primary_color_id") REFERENCES "colors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -295,7 +295,9 @@ model Animal {
   speciesId            String                @map("species_id")
   species              Species               @relation(fields: [speciesId], references: [id])
   breeds               Breed[]
-  colors               Color[]
+  colors               Color[] // all colors, including the primary
+  primaryColorId       String               @map("primary_color_id")
+  primaryColor         Color                @relation("PrimaryColor", fields: [primaryColorId], references: [id])
   characteristics      Characteristic[]
   animalImages         AnimalImage[]
   medicalRecords       MedicalRecord[]
@@ -359,9 +361,10 @@ model Breed {
 }
 
 model Color {
-  id      String   @id @default(cuid())
-  name    String   @unique // "Black", "White", "Brown", "Brindle", "Tabby"
-  animals Animal[]
+  id                String    @id @default(cuid())
+  name              String    @unique // "Black", "White", "Brown", "Brindle", "Tabby"
+  animals           Animal[] // animals that have this color (in their full color set)
+  primaryForAnimals Animal[]  @relation("PrimaryColor") // animals where this is the primary color
 
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -26,8 +26,8 @@ import {
   getRandomDateWithinLastDays,
   getRandomItem,
 } from "@/app/lib/utils/seeding-utils";
-import {env} from "prisma/config";
-import {PrismaPg} from "@prisma/adapter-pg";
+import { env } from "prisma/config";
+import { PrismaPg } from "@prisma/adapter-pg";
 
 const connectionString = `${process.env.DATABASE_URL ?? env("DATABASE_URL")}`;
 const adapter = new PrismaPg({ connectionString });
@@ -224,6 +224,7 @@ const animalSeedData = [
     species: allSpecies.DOG,
     breeds: [allSpecies.DOG.breeds.GOLDEN_RETRIEVER],
     colors: [allColors.GOLDEN],
+    primaryColor: allColors.GOLDEN,
     characteristics: [
       allCharacteristics.GOOD_WITH_KIDS,
       allCharacteristics.GOOD_WITH_DOGS,
@@ -243,6 +244,7 @@ const animalSeedData = [
       allSpecies.DOG.breeds.MIXED_BREED,
     ],
     colors: [allColors.WHITE],
+    primaryColor: allColors.WHITE,
     characteristics: [allCharacteristics.NEEDS_QUIET_HOME],
     intakeType: IntakeType.STRAY,
     healthStatus: AnimalHealthStatus.AWAITING_VET_EXAM,
@@ -256,6 +258,7 @@ const animalSeedData = [
     species: allSpecies.DOG,
     breeds: [allSpecies.DOG.breeds.AIREDALE_TERRIER],
     colors: [allColors.BROWN, allColors.BLACK],
+    primaryColor: allColors.BROWN,
     characteristics: [allCharacteristics.HOUSEBROKEN],
     intakeType: IntakeType.TRANSFER_IN,
     healthStatus: AnimalHealthStatus.UNDER_VET_CARE,
@@ -269,6 +272,7 @@ const animalSeedData = [
     species: allSpecies.CAT,
     breeds: [allSpecies.CAT.breeds.SIAMESE],
     colors: [allColors.WHITE, allColors.BROWN],
+    primaryColor: allColors.WHITE,
     characteristics: [allCharacteristics.GOOD_WITH_CATS],
     intakeType: IntakeType.OWNER_SURRENDER,
     healthStatus: AnimalHealthStatus.HEALTHY,
@@ -286,6 +290,7 @@ const animalSeedData = [
     species: allSpecies.CAT,
     breeds: [allSpecies.CAT.breeds.DOMESTIC_SHORTHAIR],
     colors: [allColors.GRAY, allColors.TABBY],
+    primaryColor: allColors.GRAY,
     characteristics: [],
     intakeType: IntakeType.BORN_IN_CARE,
     healthStatus: AnimalHealthStatus.AWAITING_SPAY_NEUTER,
@@ -303,6 +308,7 @@ const animalSeedData = [
     species: allSpecies.REPTILE,
     breeds: [allSpecies.REPTILE.breeds.IGUANA],
     colors: [allColors.GREEN],
+    primaryColor: allColors.GREEN,
     characteristics: [],
     intakeType: IntakeType.SEIZE,
     healthStatus: AnimalHealthStatus.AWAITING_TRIAGE,
@@ -320,6 +326,7 @@ const animalSeedData = [
     species: allSpecies.DOG,
     breeds: [allSpecies.DOG.breeds.LABRADOR, allSpecies.DOG.breeds.MIXED_BREED],
     colors: [allColors.BLACK],
+    primaryColor: allColors.BLACK,
     characteristics: [
       allCharacteristics.GOOD_WITH_KIDS,
       allCharacteristics.HOUSEBROKEN,
@@ -339,6 +346,7 @@ const animalSeedData = [
       allSpecies.CAT.breeds.DOMESTIC_SHORTHAIR,
     ],
     colors: [allColors.TABBY, allColors.ORANGE],
+    primaryColor: allColors.TABBY,
     characteristics: [allCharacteristics.GOOD_WITH_CATS],
     intakeType: IntakeType.BORN_IN_CARE,
     healthStatus: AnimalHealthStatus.HEALTHY,
@@ -352,6 +360,7 @@ const animalSeedData = [
     species: allSpecies.DOG,
     breeds: [allSpecies.DOG.breeds.GOLDEN_RETRIEVER],
     colors: [allColors.GOLDEN],
+    primaryColor: allColors.GOLDEN,
     characteristics: [allCharacteristics.DEAF],
     intakeType: IntakeType.TRANSFER_IN,
     healthStatus: AnimalHealthStatus.UNDER_VET_CARE,
@@ -707,6 +716,15 @@ async function seedAnimalsAndRelations() {
         .filter((dbColor) => colorNames.includes(dbColor.name))
         .map((c) => ({ id: c.id }));
 
+      const primaryColorName = animalData.primaryColor.name;
+      const primaryColor = dbColors.find((c) => c.name === primaryColorName);
+      if (!primaryColor) {
+        console.warn(
+          `Skipping animal "${animalData.name}" because its primary color "${primaryColorName}" was not found.`,
+        );
+        continue;
+      }
+
       const characteristicNames = animalData.characteristics.map((c) => c.name);
       const connectedChars = dbChars
         .filter((dbChar) => characteristicNames.includes(dbChar.name))
@@ -731,6 +749,7 @@ async function seedAnimalsAndRelations() {
           species: { connect: { id: species.id } },
           breeds: { connect: connectedBreeds },
           colors: { connect: connectedColors },
+          primaryColor: { connect: { id: primaryColor.id } },
           characteristics: { connect: connectedChars },
           animalImages: {
             create: animalData.images.map((imageUrl) => ({ url: imageUrl })),
@@ -815,7 +834,7 @@ async function seedAnimalsAndRelations() {
             // Random due date between 3 and 7 days from now
             dueDate: new Date(
               Date.now() +
-                (Math.floor(Math.random() * 5) + 3) * 24 * 60 * 60 * 1000,
+              (Math.floor(Math.random() * 5) + 3) * 24 * 60 * 60 * 1000,
             ),
           },
         });


### PR DESCRIPTION
## What
Animals can now have multiple colors with one designated primary color, replacing the previous single color model. Sets up the data model for the upcoming public color filter.

## Schema
- Adds required `primaryColorId` (FK to Color) on Animal, alongside the existing many-to-many `colors` relation
- `colors` holds the full set (including the primary); `primaryColor` is the designated pointer
- Color names are globally unique (existing constraint), so name-based de-duping in the UI is safe

## Changes
- **Form:** single color picker → required primary-color select + an additional-colors multi-select (combobox); submits `additionalColors` as repeated fields
- **Actions:** `_createAnimal` / `_updateAnimal` write `primaryColor` and the full `colors` set; validate all submitted colors exist and aren't soft-deleted; surface specific errors via ConflictError/NotFoundError
- **Edit pre-fill:** `_fetchAnimalById` returns `primaryColorId`; the form reads the real primary (no longer relying on unordered `colors[0]`)
- **Dashboard card:** shows Primary Color (from the relation) + Other Colors
- **Public pet page:** shows Primary Color + Other Colors
- **Seed:** each animal now declares an explicit `primaryColor`

## ⚠️ Deployment
This migration adds a **required** column, so it **cannot** be applied to a populated database with `prisma migrate deploy`. Because production is seed-only (no real user data), deploy by **resetting and reseeding prod**:
1. Confirm production contains only seed data (no real accounts/applications/ records created through the live app).
2. `prisma migrate reset` against production, which replays migrations on an empty DB and reseeds.

If production ever contains real data, this approach must change (add the column nullable, backfill, then enforce), but that does not apply now.