### PR TITLE
Improve public pet filtering + add favorites page

### DIFF
--- a/app/(publicpages)/page.tsx
+++ b/app/(publicpages)/page.tsx
@@ -1,12 +1,8 @@
 import Link from "next/link";
 import WelcomeImage from "../../components/public-pages/welcome-image";
 import { fetchLatestPublicAnimals } from "../lib/data/public.data";
-import Image from "next/image";
-import { shimmer, toBase64 } from "../lib/utils/image-loading-placeholder";
-import { calculateAgeString } from "../lib/utils/date-utils";
 import { Suspense } from "react";
-import { PhotoIcon } from "@heroicons/react/16/solid";
-import LikeButton from "../../components/public-pages/like-button";
+import PetCard from "@/components/public-pages/pets/pet-card";
 import { auth } from "@/auth";
 import LatestPetsSkeleton from "@/components/public-pages/latest-pets-skeleton";
 
@@ -133,58 +129,12 @@ const LatestPetsContent = async () => {
   const currentUserPersonId = session?.user?.personId;
 
   return (
-    <div className="mt-6 grid gap-4 gap-y-14 grid-cols-[repeat(auto-fit,minmax(--spacing(40),1fr))]">
-      {latestAnimals.map((animal) => {
-        const isLikedByCurrentUser = !!(
-          currentUserPersonId && animal.likes?.length > 0
-        );
-        const ageString = calculateAgeString({
-          birthDate: animal.birthDate,
-          simple: true,
-        });
-        return (
-          <Link
-            href={`/pets/${animal.id}`}
-            key={animal.id}
-            className="relative max-w-56 bg-card block hover:shadow-lg transition-shadow duration-150 ease-in-out group rounded-lg"
-          >
-            <div className="relative w-full aspect-square overflow-hidden rounded-lg">
-              {animal.animalImages?.length > 0 ? (
-                <Image
-                  src={animal.animalImages[0].url}
-                  alt={`Photo of ${animal.name}`}
-                  fill
-                  sizes="(max-width: 480px) 80vw, (max-width: 768px) 40vw, (max-width: 1024px) 30vw, 224px"
-                  placeholder={`data:image/svg+xml;base64,${toBase64(
-                    shimmer(224, 224),
-                  )}`}
-                  className="rounded-md object-cover group-hover:scale-110 transition-transform duration-300 ease-in-out"
-                />
-              ) : (
-                <div className="w-full h-full bg-muted rounded-md flex items-center justify-center">
-                  <PhotoIcon className="w-16 h-16 text-muted-foreground" />
-                </div>
-              )}
-            </div>
-
-            <div className="absolute -bottom-6.5 left-2 right-2">
-              <div className="text-sm flex flex-col px-4 py-2 bg-card shadow-lg rounded-lg relative">
-                <span className="font-semibold w-full">{animal.name}</span>
-                <div className="text-xs text-muted-foreground">
-                  <span>{`${ageString} • ${animal.city}`}</span>
-                </div>
-                <div className="absolute -top-4 right-2 z-10">
-                  <LikeButton
-                    animalId={animal.id}
-                    currentUserPersonId={currentUserPersonId}
-                    isLikedByCurrentUser={isLikedByCurrentUser}
-                  />
-                </div>
-              </div>
-            </div>
-          </Link>
-        );
-      })}
+    <div className="mt-6 flex flex-wrap justify-center gap-4 gap-y-14">
+      {latestAnimals.map((animal) => (
+        <div key={animal.id} className="w-44">
+          <PetCard pet={animal} currentUserPersonId={currentUserPersonId} />
+        </div>
+      ))}
     </div>
   );
 };

--- a/app/(publicpages)/pets/favorites/page.tsx
+++ b/app/(publicpages)/pets/favorites/page.tsx
@@ -1,0 +1,26 @@
+import { auth } from "@/auth";
+import LoginPromptModal from "@/components/login-prompt-modal";
+import FavoritesGrid from "@/components/public-pages/pets/favorites/favorites-grid";
+
+const Page = async () => {
+  const session = await auth();
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <div className="text-3xl font-medium">My Favorites</div>
+        <div className="text-sm text-gray-500">Pets you&apos;ve liked</div>
+      </div>
+
+      {session?.user?.personId ? (
+        <FavoritesGrid />
+      ) : (
+        <div className="text-center text-muted-foreground mt-10">
+          <p>Sign in to see the pets you&apos;ve liked.</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Page;

--- a/app/(publicpages)/pets/page.tsx
+++ b/app/(publicpages)/pets/page.tsx
@@ -1,20 +1,49 @@
 import Search from "../../../components/search";
-import { fetchSpecies } from "@/app/lib/data/public.data";
+import { fetchSpecies, fetchColors } from "@/app/lib/data/public.data";
 import PetGrid from "@/components/public-pages/pets/pet-grid";
 import CategoryList from "@/components/public-pages/pets/category-list";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ServerSideSort } from "@/components/table-common/server-side-sort";
+import { ResetFilters } from "@/components/public-pages/pets/reset-filters";
 import { SearchParamsType } from "@/app/lib/types";
+import { SexOptions, SizeOptions } from "@/components/public-pages/pets/pets-filter-options";
 
 interface Props {
   searchParams: SearchParamsType;
 }
 
+const SORT_OPTIONS = [
+  { label: "Newest", value: "createdAt.desc" },
+  { label: "Oldest", value: "createdAt.asc" },
+  { label: "Youngest", value: "birthDate.desc" },
+  { label: "Oldest pets", value: "birthDate.asc" },
+  { label: "Name A–Z", value: "name.asc" },
+];
+
 const Page = async ({ searchParams }: Props) => {
-  const { page = "1", category = "", query = "" } = await searchParams;
+  const {
+    page = "1",
+    category = "",
+    query = "",
+    color = "",
+    sex = "",
+    size = "",
+    sort = "",
+  } = await searchParams;
   const speciesName = category;
+  const colorNames = color;
   const currentPage = Number(page);
 
-  // get the list of species
-  const speciesList = await fetchSpecies();
+  // get the list of species and colors for the filters
+  const [speciesList, colorList] = await Promise.all([
+    fetchSpecies(),
+    fetchColors(),
+  ]);
+
+  const colorOptions = colorList.map((c) => ({
+    label: c.name,
+    value: c.name,
+  }));
 
   return (
     <div className="space-y-4">
@@ -27,11 +56,42 @@ const Page = async ({ searchParams }: Props) => {
 
       <div className="flex flex-row flex-wrap items-center justify-between gap-x-2 gap-y-2">
         <div className="w-96">
-          <Search placeholder="Search pet name" />
+          <Search placeholder="Search by name, breed, or city" />
         </div>
 
-        {/* category option */}
-        <CategoryList species={speciesList} speciesName={speciesName} />
+        <div className="flex flex-row flex-wrap items-center gap-2">
+          <CategoryList species={speciesList} speciesName={speciesName} />
+          <ServerSideFacetedFilter
+            title="Color"
+            paramKey="color"
+            options={colorOptions}
+          />
+          <ServerSideFacetedFilter
+            title="Sex"
+            paramKey="sex"
+            options={SexOptions}
+          />
+          <ServerSideFacetedFilter
+            title="Size"
+            paramKey="size"
+            options={SizeOptions}
+          />
+          <ServerSideSort
+            paramKey="sort"
+            placeholder="Sort by"
+            options={SORT_OPTIONS}
+          />
+          <ResetFilters
+            filterParamKeys={[
+              "query",
+              "category",
+              "color",
+              "sex",
+              "size",
+              "sort",
+            ]}
+          />
+        </div>
       </div>
 
       {/* pets card */}
@@ -39,6 +99,10 @@ const Page = async ({ searchParams }: Props) => {
         query={query}
         currentPage={currentPage}
         speciesName={speciesName}
+        colorNames={colorNames}
+        sex={sex}
+        size={size}
+        sort={sort}
       />
     </div>
   );

--- a/app/lib/actions/animal.actions.ts
+++ b/app/lib/actions/animal.actions.ts
@@ -415,17 +415,6 @@ const _togglePetLike = async (
       return { success: false, message: "Pet not found." };
     }
 
-    const isLikeableStatus =
-      pet.listingStatus === "PUBLISHED" ||
-      pet.listingStatus === "PENDING_ADOPTION";
-    if (!isLikeableStatus) {
-      return {
-        success: false,
-        message:
-          "This pet is not available for interaction at its current status.",
-      };
-    }
-
     const existingLike = await prisma.like.findUnique({
       where: {
         userId_animalId: {
@@ -436,6 +425,8 @@ const _togglePetLike = async (
     });
 
     if (existingLike) {
+      // Unlike is always allowed, regardless of listing status, so users can
+      // clear pets from their favorites even after the pet becomes unavailable.
       await prisma.like.delete({
         where: {
           userId_animalId: {
@@ -446,10 +437,24 @@ const _togglePetLike = async (
       });
 
       revalidatePath("/pets");
+      revalidatePath("/pets/favorites");
       revalidatePath(`/pets/${validatedAnimalId}`);
 
       return { success: true, message: "Removed from favorites." };
     } else {
+      // Creating a new like is only allowed for available pets. This guards
+      // against stale pages or crafted requests trying to like an archived pet.
+      const isLikeableStatus =
+        pet.listingStatus === "PUBLISHED" ||
+        pet.listingStatus === "PENDING_ADOPTION";
+      if (!isLikeableStatus) {
+        return {
+          success: false,
+          message:
+            "This pet is not available for interaction at its current status.",
+        };
+      }
+
       await prisma.like.create({
         data: {
           userId: personId,
@@ -458,6 +463,7 @@ const _togglePetLike = async (
       });
 
       revalidatePath("/pets");
+      revalidatePath("/pets/favorites");
       revalidatePath(`/pets/${validatedAnimalId}`);
       return { success: true, message: "Added to favorites!" };
     }

--- a/app/lib/data/public.data.ts
+++ b/app/lib/data/public.data.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@/app/lib/prisma";
 import { auth } from "@/auth";
-import { AnimalListingStatus, Prisma } from "@prisma/client";
+import { AnimalListingStatus, AnimalSize, Prisma, Sex } from "@prisma/client";
 import { cuidSchema } from "../zod-schemas/common.schemas";
 import { PublishedPetsSchema } from "../zod-schemas/animal.schemas";
 
@@ -29,37 +29,122 @@ export type PetsPayload = Prisma.AnimalGetPayload<{
 
 const ITEMS_PER_PAGE = 10
 
-export const fetchPublishedPets = async (
-  queryInput: string,
-  currentPageInput: number,
-  speciesNameInput?: string
-): Promise<{ pets: PetsPayload[]; totalPages: number }> => {
+// Allowlist of sortable fields → Prisma orderBy. Never pass raw user input into
+// orderBy; anything not in this map falls back to the default (newest first).
+const SORT_MAP: Record<string, Prisma.AnimalOrderByWithRelationInput> = {
+  "createdAt.desc": { createdAt: "desc" }, // Newest
+  "createdAt.asc": { createdAt: "asc" }, // Oldest listing
+  "birthDate.desc": { birthDate: "desc" }, // Youngest
+  "birthDate.asc": { birthDate: "asc" }, // Oldest pet
+  "name.asc": { name: "asc" }, // Name A–Z
+};
+
+const DEFAULT_SORT: Prisma.AnimalOrderByWithRelationInput = { createdAt: "desc" };
+
+export interface FetchPublishedPetsArgs {
+  query: string;
+  currentPage: number;
+  speciesName?: string;
+  color?: string;
+  sex?: string;
+  size?: string;
+  sort?: string;
+}
+
+export const fetchPublishedPets = async ({
+  query: queryInput,
+  currentPage: currentPageInput,
+  speciesName: speciesNameInput,
+  color: colorInput,
+  sex: sexInput,
+  size: sizeInput,
+  sort: sortInput,
+}: FetchPublishedPetsArgs): Promise<{
+  pets: PetsPayload[];
+  totalPages: number;
+}> => {
+  // Treat empty strings as "not provided" so optional schemas (especially the
+  // regex-validated `sort`) skip them instead of failing validation. The page
+  // passes "" defaults for absent params, which would otherwise trip the sort
+  // regex on the unfiltered /pets view.
+  const emptyToUndefined = (v?: string) => (v ? v : undefined);
+
   const validatedArgs = PublishedPetsSchema.safeParse({
     query: queryInput,
     currentPage: currentPageInput,
-    speciesName: speciesNameInput,
+    speciesName: emptyToUndefined(speciesNameInput),
+    color: emptyToUndefined(colorInput),
+    sex: emptyToUndefined(sexInput),
+    size: emptyToUndefined(sizeInput),
+    sort: emptyToUndefined(sortInput),
   });
 
   if (!validatedArgs.success) {
+    console.error(
+      "Invalid arguments for fetching pets:",
+      validatedArgs.error.flatten().fieldErrors,
+    );
     throw new Error("Invalid arguments for fetching pets.");
   }
-  const { query, currentPage, speciesName } = validatedArgs.data;
+  const { query, currentPage, speciesName, color, sex, size, sort } =
+    validatedArgs.data;
+
+  // Split comma-joined facet params into clean lists. Sex/size are validated
+  // against the real Prisma enums so crafted values can't reach the query.
+  const colorNames = color?.split(",").filter(Boolean) ?? [];
+
+  const sexValues = (sex?.split(",").filter(Boolean) ?? []).filter(
+    (v): v is Sex => (Object.values(Sex) as string[]).includes(v),
+  );
+  const sizeValues = (size?.split(",").filter(Boolean) ?? []).filter(
+    (v): v is AnimalSize =>
+      (Object.values(AnimalSize) as string[]).includes(v),
+  );
+
+  const orderBy = (sort && SORT_MAP[sort]) || DEFAULT_SORT;
 
   const session = await auth();
   const personId = session?.user?.personId;
 
   const whereClause: Prisma.AnimalWhereInput = {
-    name: {
-      contains: query,
-      mode: "insensitive",
-    },
     listingStatus: {
       in: [AnimalListingStatus.PUBLISHED, AnimalListingStatus.PENDING_ADOPTION],
     },
+    // Free-text search across name, breed, and city so adopters don't need to
+    // know a pet's assigned name. Only applied when there's a query; combines
+    // as AND with the species and color filters below.
+    ...(query && {
+      OR: [
+        { name: { contains: query, mode: "insensitive" } },
+        {
+          breeds: {
+            some: { name: { contains: query, mode: "insensitive" } },
+          },
+        },
+        { city: { contains: query, mode: "insensitive" } },
+      ],
+    }),
     ...(speciesName && {
       species: {
         name: speciesName,
       },
+    }),
+    // OR-within color (any selected color), AND-across with species + query.
+    // `some` matches the animal's full color set, so a pet shows if any of its
+    // colors (primary or secondary) is one of the selected names.
+    ...(colorNames.length > 0 && {
+      colors: {
+        some: {
+          name: { in: colorNames },
+        },
+      },
+    }),
+    // Sex and size are enum fields (not relations), matched directly with `in`.
+    ...(sexValues.length > 0 && {
+      sex: { in: sexValues },
+    }),
+    ...(sizeValues.length > 0 && {
+      size: { in: sizeValues },
     }),
   };
 
@@ -94,9 +179,7 @@ export const fetchPublishedPets = async (
           }),
           listingStatus: true,
         },
-        orderBy: {
-          createdAt: "desc",
-        },
+        orderBy,
         take: ITEMS_PER_PAGE,
         skip: offset,
       }),
@@ -112,11 +195,102 @@ export const fetchPublishedPets = async (
 
 export const fetchSpecies = async () => {
   try {
-    const species = await prisma.species.findMany();
+    const species = await prisma.species.findMany({
+      where: { deletedAt: null },
+      orderBy: { name: "asc" },
+    });
     return species;
   } catch (error) {
     console.error("Error fetching species.", error);
     throw new Error("Error fetching species.");
+  }
+};
+
+export const fetchColors = async () => {
+  try {
+    const colors = await prisma.color.findMany({
+      where: { deletedAt: null },
+      orderBy: { name: "asc" },
+    });
+    return colors;
+  } catch (error) {
+    console.error("Error fetching colors.", error);
+    throw new Error("Error fetching colors.");
+  }
+};
+
+export type FavoritePet = {
+  id: string;
+  name: string;
+  city: string | null;
+  birthDate: Date;
+  listingStatus: AnimalListingStatus;
+  animalImages: { url: string }[];
+  // Always present (these are the user's own likes), kept for PetCard's heart state.
+  likes: { userId: string }[];
+  isAvailable: boolean;
+};
+
+const AVAILABLE_STATUSES: AnimalListingStatus[] = [
+  AnimalListingStatus.PUBLISHED,
+  AnimalListingStatus.PENDING_ADOPTION,
+];
+
+/**
+ * Fetches the signed-in user's liked pets, including ones that are no longer
+ * available. Unavailable pets are flagged via `isAvailable` so the UI can grey
+ * them out — we never expose WHY a pet is unavailable (archiveReason is never
+ * selected), so adopted/transferred/deceased all read as a neutral "unavailable".
+ *
+ * Ordering: most recently liked first, but unavailable pets are always pushed to
+ * the end (recency preserved within each group).
+ */
+export const fetchFavoritePets = async (): Promise<{
+  pets: FavoritePet[];
+}> => {
+  const session = await auth();
+  const personId = session?.user?.personId;
+
+  if (!personId) {
+    return { pets: [] };
+  }
+
+  try {
+    const likes = await prisma.like.findMany({
+      where: { userId: personId },
+      orderBy: { createdAt: "desc" }, // most recently liked first
+      select: {
+        animal: {
+          select: {
+            id: true,
+            name: true,
+            city: true,
+            birthDate: true,
+            listingStatus: true,
+            animalImages: {
+              select: { url: true },
+              take: 1,
+            },
+          },
+        },
+      },
+    });
+
+    const pets: FavoritePet[] = likes.map((like) => ({
+      ...like.animal,
+      // This is the user's own like list, so every pet is liked by them.
+      likes: [{ userId: personId }],
+      isAvailable: AVAILABLE_STATUSES.includes(like.animal.listingStatus),
+    }));
+
+    // Available first (recency preserved), then unavailable (recency preserved).
+    const available = pets.filter((p) => p.isAvailable);
+    const unavailable = pets.filter((p) => !p.isAvailable);
+
+    return { pets: [...available, ...unavailable] };
+  } catch (error) {
+    console.error("Error fetching favorite pets.", error);
+    throw new Error("Error fetching favorite pets.");
   }
 };
 

--- a/app/lib/zod-schemas/animal.schemas.ts
+++ b/app/lib/zod-schemas/animal.schemas.ts
@@ -24,11 +24,23 @@ const speciesNameSchema = z
   })
   .optional();
 
-export const PublishedPetsSchema = z.object({
-  query: searchQuerySchema,
-  currentPage: currentPageSchema,
-  speciesName: speciesNameSchema,
-});
+// Raw comma-joined color names from the URL (e.g. "Black,Brown").
+// Split into an array in the fetcher, mirroring the faceted filter's param handling.
+const colorParamSchema = z
+  .string()
+  .max(200, {
+    error: "Color filter is too long.",
+  })
+  .optional();
+
+// Generic comma-joined facet param (e.g. "MALE,FEMALE" or "SMALL,MEDIUM").
+// Values are validated against the real enum in the fetcher before use.
+const facetParamSchema = z
+  .string()
+  .max(100, {
+    error: "Filter value is too long.",
+  })
+  .optional();
 
 export const sortSchema = z
   .string()
@@ -36,6 +48,16 @@ export const sortSchema = z
     error: "Sort must be in 'field.direction' format",
   })
   .optional();
+
+export const PublishedPetsSchema = z.object({
+  query: searchQuerySchema,
+  currentPage: currentPageSchema,
+  speciesName: speciesNameSchema,
+  color: colorParamSchema,
+  sex: facetParamSchema,
+  size: facetParamSchema,
+  sort: sortSchema,
+});
 
 export const MyApplicationsSchema = z.object({
   query: searchQuerySchema,

--- a/components/public-pages/nav/top-nav-wrapper.tsx
+++ b/components/public-pages/nav/top-nav-wrapper.tsx
@@ -15,9 +15,10 @@ const TopNavWrapper = async () => {
   const navLinks = [
     { name: "Home", href: "/" },
     { name: "Pets", href: "/pets" },
+    ...(session ? [{ name: "Favorites", href: "/pets/favorites" }] : []),
     { name: "About", href: "/about" },
     { name: "Contact", href: "/contact" },
-    { name: "Dashboard", href: dashboardHref }, // Use the dynamic href
+    { name: "Dashboard", href: dashboardHref },
   ];
 
   return (

--- a/components/public-pages/pets/favorites/favorites-grid.tsx
+++ b/components/public-pages/pets/favorites/favorites-grid.tsx
@@ -1,0 +1,47 @@
+import { fetchFavoritePets } from "@/app/lib/data/public.data";
+import { auth } from "@/auth";
+import PetCard from "../pet-card";
+
+const FavoritesGrid = async () => {
+  const session = await auth();
+  const currentUserPersonId = session?.user?.personId;
+
+  const { pets } = await fetchFavoritePets();
+
+  if (pets.length === 0) {
+    return (
+      <div className="text-center text-muted-foreground mt-10">
+        <p>You haven&apos;t liked any pets yet.</p>
+        <p className="text-sm mt-1">
+          Tap the heart on a pet to save it here.
+        </p>
+      </div>
+    );
+  }
+
+  const hasUnavailable = pets.some((pet) => !pet.isAvailable);
+
+  return (
+    <>
+      <div className="my-6 mb-12 grid gap-4 gap-y-14 grid-cols-[repeat(auto-fill,minmax(--spacing(40),1fr))]">
+        {pets.map((pet) => (
+          <PetCard
+            key={pet.id}
+            pet={pet}
+            currentUserPersonId={currentUserPersonId}
+            isAvailable={pet.isAvailable}
+          />
+        ))}
+      </div>
+
+      {hasUnavailable && (
+        <p className="text-center text-xs text-muted-foreground mb-8">
+          Greyed-out pets are no longer available. You can remove them by tapping
+          the heart.
+        </p>
+      )}
+    </>
+  );
+};
+
+export default FavoritesGrid;

--- a/components/public-pages/pets/pet-card.tsx
+++ b/components/public-pages/pets/pet-card.tsx
@@ -1,0 +1,114 @@
+import { PhotoIcon } from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import clsx from "clsx";
+import { shimmer, toBase64 } from "@/app/lib/utils/image-loading-placeholder";
+import LikeButton from "../like-button";
+import { calculateAgeString } from "@/app/lib/utils/date-utils";
+
+export interface PetCardData {
+  id: string;
+  name: string;
+  city: string | null;
+  birthDate: Date;
+  animalImages: { url: string }[];
+  likes?: { userId: string }[];
+}
+
+interface PetCardProps {
+  pet: PetCardData;
+  currentUserPersonId: string | undefined;
+  /**
+   * When false, the card is rendered greyed-out with an "Unavailable" badge and
+   * is NOT clickable through to the detail page (which would 404 for archived
+   * pets). The like button stays interactive so the user can still unlike it.
+   */
+  isAvailable?: boolean;
+}
+
+const PetCard = ({
+  pet,
+  currentUserPersonId,
+  isAvailable = true,
+}: PetCardProps) => {
+  const isLikedByCurrentUser = !!(
+    currentUserPersonId && (pet.likes?.length ?? 0) > 0
+  );
+  const ageString = calculateAgeString({
+    birthDate: pet.birthDate,
+    simple: true,
+  });
+
+  const inner = (
+    <>
+      <div className="relative w-full aspect-square overflow-hidden rounded-lg">
+        {pet.animalImages?.length > 0 ? (
+          <Image
+            src={pet.animalImages[0].url}
+            alt={`Photo of ${pet.name}`}
+            fill
+            sizes="(max-width: 480px) 80vw, (max-width: 768px) 40vw, (max-width: 1024px) 30vw, 224px"
+            placeholder={`data:image/svg+xml;base64,${toBase64(
+              shimmer(224, 224),
+            )}`}
+            className={clsx(
+              "rounded-md object-cover transition-transform duration-300 ease-in-out",
+              isAvailable && "group-hover:scale-110",
+              !isAvailable && "grayscale",
+            )}
+          />
+        ) : (
+          <div className="w-full h-full bg-muted rounded-md flex items-center justify-center">
+            <PhotoIcon className="w-16 h-16 text-muted-foreground" />
+          </div>
+        )}
+
+        {!isAvailable && (
+          <div className="absolute inset-0 rounded-lg bg-background/40 flex items-start justify-start p-2">
+            <span className="rounded-full bg-background/90 px-2 py-0.5 text-xs font-medium text-muted-foreground shadow">
+              Unavailable
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="absolute -bottom-6.5 left-2 right-2">
+        <div className="text-sm flex flex-col px-4 py-2 bg-card shadow-lg rounded-lg relative">
+          <span className="font-semibold w-full">{pet.name}</span>
+          <div className="text-xs text-muted-foreground">
+            <span>{`${ageString} • ${pet.city ?? ""}`}</span>
+          </div>
+          <div className="absolute -top-4 right-2 z-10">
+            <LikeButton
+              animalId={pet.id}
+              currentUserPersonId={currentUserPersonId}
+              isLikedByCurrentUser={isLikedByCurrentUser}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+
+  const wrapperClass =
+    "relative max-w-56 bg-card block rounded-lg group transition-shadow duration-150 ease-in-out";
+
+  // Available pets link through to the detail page; unavailable ones render a
+  // non-clickable div (the detail fetcher only serves available pets, so a link
+  // would 404). The like button inside still works in both cases.
+  if (isAvailable) {
+    return (
+      <Link href={`/pets/${pet.id}`} className={clsx(wrapperClass, "hover:shadow-lg")}>
+        {inner}
+      </Link>
+    );
+  }
+
+  return (
+    <div className={clsx(wrapperClass, "cursor-default")} aria-disabled="true">
+      {inner}
+    </div>
+  );
+};
+
+export default PetCard;

--- a/components/public-pages/pets/pet-grid.tsx
+++ b/components/public-pages/pets/pet-grid.tsx
@@ -1,28 +1,39 @@
 import { fetchPublishedPets } from "@/app/lib/data/public.data";
 import { auth } from "@/auth";
-import { PhotoIcon } from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
-import { shimmer, toBase64 } from "@/app/lib/utils/image-loading-placeholder";
-import LikeButton from "../like-button";
-import { calculateAgeString } from "@/app/lib/utils/date-utils";
+import PetCard from "./pet-card";
 import { SimplePagination } from "@/components/simple-pagination";
 
 interface Props {
   query: string;
   currentPage: number;
   speciesName: string;
+  colorNames: string;
+  sex: string;
+  size: string;
+  sort: string;
 }
 
-const PetGrid = async ({ query, currentPage, speciesName }: Props) => {
+const PetGrid = async ({
+  query,
+  currentPage,
+  speciesName,
+  colorNames,
+  sex,
+  size,
+  sort,
+}: Props) => {
   const session = await auth();
   const currentUserPersonId = session?.user?.personId;
 
-  const { pets, totalPages } = await fetchPublishedPets(
+  const { pets, totalPages } = await fetchPublishedPets({
     query,
     currentPage,
     speciesName,
-  );
+    color: colorNames,
+    sex,
+    size,
+    sort,
+  });
 
   if (pets.length === 0) {
     return (
@@ -34,59 +45,14 @@ const PetGrid = async ({ query, currentPage, speciesName }: Props) => {
 
   return (
     <>
-      <div className="my-6 mb-12 grid gap-4 gap-y-14 grid-cols-[repeat(auto-fit,minmax(--spacing(40),1fr))]">
-        {pets.map((pet) => {
-          const isLikedByCurrentUser = !!(
-            currentUserPersonId && pet.likes?.length > 0
-          );
-          const ageString = calculateAgeString({
-            birthDate: pet.birthDate,
-            simple: true,
-          });
-
-          return (
-            <Link
-              href={`/pets/${pet.id}`}
-              key={pet.id}
-              className="relative max-w-56 bg-card block hover:shadow-lg transition-shadow duration-150 ease-in-out group rounded-lg"
-            >
-              <div className="relative w-full aspect-square overflow-hidden rounded-lg">
-                {pet.animalImages?.length > 0 ? (
-                  <Image
-                    src={pet.animalImages[0].url}
-                    alt={`Photo of ${pet.name}`}
-                    fill
-                    sizes="(max-width: 480px) 80vw, (max-width: 768px) 40vw, (max-width: 1024px) 30vw, 224px"
-                    placeholder={`data:image/svg+xml;base64,${toBase64(
-                      shimmer(224, 224),
-                    )}`}
-                    className="rounded-md object-cover group-hover:scale-110 transition-transform duration-300 ease-in-out"
-                  />
-                ) : (
-                  <div className="w-full h-full bg-muted rounded-md flex items-center justify-center">
-                    <PhotoIcon className="w-16 h-16 text-muted-foreground" />
-                  </div>
-                )}
-              </div>
-
-              <div className="absolute -bottom-6.5 left-2 right-2">
-                <div className="text-sm flex flex-col px-4 py-2 bg-card shadow-lg rounded-lg relative">
-                  <span className="font-semibold w-full">{pet.name}</span>
-                  <div className="text-xs text-muted-foreground">
-                    <span>{`${ageString} • ${pet.city}`}</span>
-                  </div>
-                  <div className="absolute -top-4 right-2 z-10">
-                    <LikeButton
-                      animalId={pet.id}
-                      currentUserPersonId={currentUserPersonId}
-                      isLikedByCurrentUser={isLikedByCurrentUser}
-                    />
-                  </div>
-                </div>
-              </div>
-            </Link>
-          );
-        })}
+      <div className="my-6 mb-12 grid gap-4 gap-y-14 grid-cols-[repeat(auto-fill,minmax(--spacing(40),1fr))]">
+        {pets.map((pet) => (
+          <PetCard
+            key={pet.id}
+            pet={pet}
+            currentUserPersonId={currentUserPersonId}
+          />
+        ))}
       </div>
       <div className="flex justify-center">
         <SimplePagination totalPages={totalPages} />

--- a/components/public-pages/pets/pets-filter-options.ts
+++ b/components/public-pages/pets/pets-filter-options.ts
@@ -1,0 +1,23 @@
+import { Sex, AnimalSize } from "@prisma/client";
+
+// Plain { label, value } options for the public pets faceted filters.
+//
+// NOTE: no `icon` field here on purpose. These options are created in a Server
+// Component (page.tsx) and passed as props into the client-side faceted filter.
+// A lucide icon is a React component and can't be serialized across the
+// server→client boundary ("Only plain objects can be passed..."). The color
+// filter beside these is also icon-less, so this stays visually consistent.
+
+// UNKNOWN is intentionally omitted — adopters filter for "male" or "female";
+// pets with UNKNOWN sex simply don't match a sex filter (they show when none set).
+export const SexOptions: { label: string; value: string }[] = [
+  { label: "Male", value: Sex.MALE },
+  { label: "Female", value: Sex.FEMALE },
+];
+
+export const SizeOptions: { label: string; value: string }[] = [
+  { label: "Small", value: AnimalSize.SMALL },
+  { label: "Medium", value: AnimalSize.MEDIUM },
+  { label: "Large", value: AnimalSize.LARGE },
+  { label: "Extra Large", value: AnimalSize.XLARGE },
+];

--- a/components/public-pages/pets/reset-filters.tsx
+++ b/components/public-pages/pets/reset-filters.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSearchParams, usePathname, useRouter } from "next/navigation";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ResetFiltersProps {
+  /** param keys that count toward "isFiltered" (e.g. "query", "category", "color") */
+  filterParamKeys?: string[];
+}
+
+export function ResetFilters({
+  filterParamKeys = ["query", "category", "color"],
+}: ResetFiltersProps) {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const isFiltered = filterParamKeys.some((key) => searchParams.has(key));
+
+  if (!isFiltered) return null;
+
+  return (
+    <Button
+      variant="ghost"
+      onClick={() => router.push(pathname)}
+      className="h-8 px-2 lg:px-3"
+    >
+      Reset
+      <X className="ml-2 h-4 w-4" />
+    </Button>
+  );
+}

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -26,21 +26,28 @@ const Search = ({ placeholder }: SearchProps) => {
     replace(`${pathname}?${params.toString()}`);
   }, 300);
 
+  const currentQuery = searchParams.get("query")?.toString() ?? "";
+
   return (
     <div className="relative">
       <label htmlFor="search" className="sr-only">
         Search
       </label>
       <Input
+        // Keying on the URL query makes the uncontrolled input remount when the
+        // param changes externally (e.g. a Reset that clears it), so the visible
+        // text stays in sync with the URL. Typing doesn't remount because the
+        // debounced handler sets query to exactly what was typed.
+        key={currentQuery}
         id="search"
         name="search"
         type="search"
-        className="pl-10" 
+        className="pl-10"
         placeholder={placeholder}
         onChange={(e) => {
           handleSearch(e.target.value);
         }}
-        defaultValue={searchParams.get("query")?.toString()}
+        defaultValue={currentQuery}
       />
       <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-[18px] w-[18px] -translate-y-1/2 text-gray-500" />
     </div>

--- a/components/table-common/data-table-toolbar.tsx
+++ b/components/table-common/data-table-toolbar.tsx
@@ -42,6 +42,8 @@ export function DataTableToolbar<TData>({
     router.replace(`${pathname}?${params.toString()}`);
   }, 300);
 
+  const currentQuery = searchParams.get("query")?.toString() ?? "";
+
   const isFiltered =
     searchParams.has("query") ||
     filterParamKeys.some((key) => searchParams.has(key));
@@ -51,10 +53,15 @@ export function DataTableToolbar<TData>({
       <div className="grid grid-cols-1 items-center gap-y-2 @[736px]/toolbar:grid-cols-[200px_1fr] @[736px]/toolbar:gap-x-4">
         <div>
           <Input
+            // Keying on the URL query remounts the uncontrolled input when the
+            // param changes externally (e.g. Reset), keeping the visible text in
+            // sync with the URL. Typing doesn't remount: the debounced handler
+            // sets query to exactly what was typed.
+            key={currentQuery}
             id={searchId}
             placeholder={searchPlaceholder}
             onChange={(e) => handleSearch(e.target.value)}
-            defaultValue={searchParams.get("query")?.toString()}
+            defaultValue={currentQuery}
             className="h-8 w-50 @[736px]/toolbar:w-full"
           />
         </div>


### PR DESCRIPTION
## What

Improves discovery on the public pets page and adds a favorites page.

### Filtering
- Color filter (multi-select; matches any of an animal's colors)
- Sex and size filters (Male/Female only on public, UNKNOWN omitted by design)
- Broadened search: name, breed, and city (was name-only)
- Sort dropdown: newest, oldest, youngest, oldest pets, name A–Z
- Species/color dropdowns now show active-only, alphabetical
- Reset button clears all filters and search

All filters combine as AND; multi-value filters are OR within themselves. Sort and enum filters are validated against an allowlist/the Prisma enums, so crafted query params can't reach the DB.

### Favorites (/pets/favorites)
- Lists the signed-in user's liked pets, newest first
- Archived pets show greyed + non-clickable with a neutral "Unavailable" badge.
- Unliking an archived pet is allowed and removes it from the list; new likes on unavailable pets are blocked server-side
- Nav link added for logged-in users

### Refactor / fixes
- Extracted a shared PetCard used by the listing, favorites, and home grids
- Fixed grid layout: listing/favorites left-aligned (auto-fill), home centered
- Fixed search inputs not clearing on reset (public + shared table toolbar)