### PR TITLE
refactor: extract shared ApplicantFieldsSection for staff adoption forms

### DIFF
--- a/app/lib/utils/form-utils.ts
+++ b/app/lib/utils/form-utils.ts
@@ -10,3 +10,27 @@ export const boolToSelectValue = (
   if (value === false) return "false";
   return undefined;
 };
+
+/**
+ * Add this to: app/lib/utils/form-utils.ts
+ * (alongside the existing toYesNo helper — same file)
+ *
+ * Builds a FormData object from a flat record of string form values, skipping
+ * null/undefined entries. Used by the staff adoption application forms whose
+ * fields are all flat strings.
+ *
+ * NOTE: This is intentionally only for flat-string forms. It is NOT suitable for
+ * the intake form, which needs special handling (array fields appended per-element,
+ * Date values serialized via toISOString). Those forms keep their bespoke onSubmit.
+ */
+export function buildApplicationFormData(
+  data: Record<string, string | undefined | null>,
+): FormData {
+  const formData = new FormData();
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== null && value !== undefined) {
+      formData.append(key, value);
+    }
+  });
+  return formData;
+}

--- a/components/dashboard/people-directory/adoption-applications/applicant-fields-section.tsx
+++ b/components/dashboard/people-directory/adoption-applications/applicant-fields-section.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { Control, UseFormWatch } from "react-hook-form";
+import { LivingSituation } from "@prisma/client";
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
+import { US_STATES } from "@/app/lib/constants/us-states";
+import { livingSituationOptions } from "@/app/lib/utils/enum-formatter";
+
+/**
+ * The exact subset of fields this section renders. Both staff adoption forms
+ * (create + edit) share these fields:
+ *  - create uses StaffAdoptionApplicationFormSchema (MyAdoptionAppFormSchema + animalId)
+ *  - edit uses MyAdoptionAppFormSchema
+ * Since the create schema is a superset, both forms' `control` are structurally
+ * compatible with Control<ApplicantFieldValues>. Each call site passes
+ * `control={form.control as Control<ApplicantFieldValues>}` — one explicit cast,
+ * the same single-cast pattern used in the intake form. The types below mirror
+ * the inferred Zod types exactly (note the "true" | "false" string unions and the
+ * required LivingSituation enum) so field names AND value types stay checked
+ * inside this component.
+ */
+export interface ApplicantFieldValues {
+  applicantName: string;
+  applicantEmail: string;
+  applicantPhone: string;
+  applicantAddressLine1: string;
+  applicantAddressLine2?: string;
+  applicantCity: string;
+  applicantState: string;
+  applicantZipCode: string;
+  livingSituation: LivingSituation;
+  householdSize: string;
+  hasYard: "true" | "false";
+  landlordPermission: "true" | "false";
+  hasChildren: "true" | "false";
+  childrenAges: string;
+  otherAnimalsDescription?: string;
+  animalExperience: string;
+  reasonForAdoption: string;
+}
+
+interface ApplicantFieldsSectionProps {
+  control: Control<ApplicantFieldValues>;
+  watch: UseFormWatch<ApplicantFieldValues>;
+}
+
+/**
+ * Renders the three shared field groups for the staff adoption application forms:
+ * Applicant Information, Home & Lifestyle, and Experience & Intent.
+ *
+ * Wording is third-person throughout, because staff complete these forms on
+ * behalf of a walk-in applicant. The public-facing MyApplicationForm uses
+ * first-person wording and is intentionally NOT served by this component.
+ */
+export const ApplicantFieldsSection = ({
+  control,
+  watch,
+}: ApplicantFieldsSectionProps) => {
+  const hasChildrenValue = watch("hasChildren");
+
+  return (
+    <>
+      {/* Applicant Information */}
+      <div className="space-y-6">
+        <h3 className="font-semibold border-b pb-2">Applicant Information</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <FormField
+            control={control}
+            name="applicantName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Full Name *</FormLabel>
+                <FormControl>
+                  <Input placeholder="John Doe" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="applicantEmail"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email *</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="you@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="applicantPhone"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Phone *</FormLabel>
+                <FormControl>
+                  <Input placeholder="(123) 456-7890" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+        <Separator />
+        <div className="space-y-6">
+          <FormField
+            control={control}
+            name="applicantAddressLine1"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Address Line 1 *</FormLabel>
+                <FormControl>
+                  <Input placeholder="123 Main St" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="applicantAddressLine2"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Address Line 2</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Apt, Suite, etc. (Optional)"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <FormField
+              control={control}
+              name="applicantCity"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>City *</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={control}
+              name="applicantState"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>State *</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a state" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {US_STATES.map((s) => (
+                        <SelectItem key={s.code} value={s.code}>
+                          {s.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={control}
+              name="applicantZipCode"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>ZIP Code *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="12345" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Home & Lifestyle */}
+      <div className="space-y-8">
+        <h3 className="font-semibold border-b pb-2">Home &amp; Lifestyle</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <FormField
+            control={control}
+            name="livingSituation"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Living Situation *</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select living situation" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {livingSituationOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="householdSize"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Household Size *</FormLabel>
+                <FormControl>
+                  <Input type="number" min="1" {...field} />
+                </FormControl>
+                <FormDescription>
+                  Including the applicant, how many people live in the home?
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="hasYard"
+            render={({ field }) => (
+              <FormItem className="space-y-3">
+                <div className="text-sm font-medium">
+                  Do they have a yard? *
+                </div>
+                <FormControl>
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="flex items-center space-x-4"
+                  >
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="true" />
+                      </FormControl>
+                      <FormLabel className="font-normal">Yes</FormLabel>
+                    </FormItem>
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="false" />
+                      </FormControl>
+                      <FormLabel className="font-normal">No</FormLabel>
+                    </FormItem>
+                  </RadioGroup>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="landlordPermission"
+            render={({ field }) => (
+              <FormItem className="space-y-3">
+                <div className="text-sm font-medium">
+                  If they rent, do they have landlord permission? *
+                </div>
+                <FormControl>
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="flex items-center space-x-4"
+                  >
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="true" />
+                      </FormControl>
+                      <FormLabel className="font-normal">Yes</FormLabel>
+                    </FormItem>
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="false" />
+                      </FormControl>
+                      <FormLabel className="font-normal">No</FormLabel>
+                    </FormItem>
+                  </RadioGroup>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={control}
+            name="hasChildren"
+            render={({ field }) => (
+              <FormItem className="space-y-3">
+                <div className="text-sm font-medium">
+                  Are there children in the home? *
+                </div>
+                <FormControl>
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    className="flex items-center space-x-4"
+                  >
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="true" />
+                      </FormControl>
+                      <FormLabel className="font-normal">Yes</FormLabel>
+                    </FormItem>
+                    <FormItem className="flex items-center space-x-2">
+                      <FormControl>
+                        <RadioGroupItem value="false" />
+                      </FormControl>
+                      <FormLabel className="font-normal">No</FormLabel>
+                    </FormItem>
+                  </RadioGroup>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          {hasChildrenValue === "true" && (
+            <FormField
+              control={control}
+              name="childrenAges"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Children&apos;s Ages *</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., 5, 12, 15" {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Please provide a comma-separated list of ages.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+        </div>
+        <Separator />
+        <FormField
+          control={control}
+          name="otherAnimalsDescription"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Other Animals</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Describe other animals in the home (species, age, temperament, etc.)."
+                  className="resize-y"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
+      {/* Experience & Intent */}
+      <div className="space-y-8">
+        <h3 className="font-semibold border-b pb-2">Experience &amp; Intent</h3>
+        <FormField
+          control={control}
+          name="animalExperience"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Animal Experience *</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Please describe their experience with animals, including past ownership."
+                  className="resize-y min-h-25"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name="reasonForAdoption"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Reason for Adoption *</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Why does this person want to adopt at this time? What are they looking for in a companion?"
+                  className="resize-y min-h-25"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </>
+  );
+};

--- a/components/dashboard/people-directory/adoption-applications/staff-adoption-application-edit-form.tsx
+++ b/components/dashboard/people-directory/adoption-applications/staff-adoption-application-edit-form.tsx
@@ -2,7 +2,7 @@
 
 import { startTransition, useActionState, useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useForm, Control, UseFormWatch } from "react-hook-form";
 import { z } from "zod";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -14,26 +14,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Separator } from "@/components/ui/separator";
+import { Form } from "@/components/ui/form";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -42,11 +23,13 @@ import {
   INITIAL_FORM_STATE,
   StaffAdoptionApplicationFormState,
 } from "@/app/lib/form-state-types";
-import { US_STATES } from "@/app/lib/constants/us-states";
-import { livingSituationOptions } from "@/app/lib/utils/enum-formatter";
-import { toYesNo } from "@/app/lib/utils/form-utils";
+import { toYesNo, buildApplicationFormData } from "@/app/lib/utils/form-utils";
 import { staffEditPersonApplication } from "@/app/lib/actions/adoption-application.actions";
 import { PersonApplicationForEditPayload } from "@/app/lib/data/people-directory/person-adoption-applications.data";
+import {
+  ApplicantFieldsSection,
+  ApplicantFieldValues,
+} from "./applicant-fields-section";
 
 type FormValues = z.infer<typeof MyAdoptionAppFormSchema>;
 
@@ -65,7 +48,7 @@ const StaffAdoptionApplicationEditForm = ({
     null,
     application.id,
     personId,
-    callbackUrl ?? null
+    callbackUrl ?? null,
   );
 
   const [state, formAction, isPending] = useActionState<
@@ -96,8 +79,6 @@ const StaffAdoptionApplicationEditForm = ({
     },
   });
 
-  const hasChildrenValue = form.watch("hasChildren");
-
   useEffect(() => {
     if (state.message) {
       toast.error(state.message);
@@ -113,14 +94,8 @@ const StaffAdoptionApplicationEditForm = ({
   }, [state, form]);
 
   const onSubmit = (data: FormValues) => {
-    const formData = new FormData();
-    Object.entries(data).forEach(([key, value]) => {
-      if (value !== null && value !== undefined) {
-        formData.append(key, value);
-      }
-    });
     startTransition(() => {
-      formAction(formData);
+      formAction(buildApplicationFormData(data));
     });
   };
 
@@ -142,371 +117,22 @@ const StaffAdoptionApplicationEditForm = ({
           </CardHeader>
 
           <CardContent className="space-y-10">
-            {/* Section 1 — Applicant Information */}
-            <div className="space-y-6">
-              <h3 className="font-semibold border-b pb-2">
-                Applicant Information
-              </h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <FormField
-                  control={form.control}
-                  name="applicantName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Full Name *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="John Doe" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantEmail"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email *</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="email"
-                          placeholder="you@example.com"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantPhone"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Phone *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="(123) 456-7890" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <Separator />
-              <div className="space-y-6">
-                <FormField
-                  control={form.control}
-                  name="applicantAddressLine1"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Address Line 1 *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="123 Main St" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantAddressLine2"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Address Line 2</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="Apt, Suite, etc. (Optional)"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                  <FormField
-                    control={form.control}
-                    name="applicantCity"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>City *</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="applicantState"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>State *</FormLabel>
-                        <Select
-                          onValueChange={field.onChange}
-                          defaultValue={field.value}
-                        >
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select a state" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {US_STATES.map((s) => (
-                              <SelectItem key={s.code} value={s.code}>
-                                {s.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="applicantZipCode"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ZIP Code *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="12345" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Section 2 — Home & Lifestyle */}
-            <div className="space-y-8">
-              <h3 className="font-semibold border-b pb-2">Home &amp; Lifestyle</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                <FormField
-                  control={form.control}
-                  name="livingSituation"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Living Situation *</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select living situation" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {livingSituationOptions.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="householdSize"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Household Size *</FormLabel>
-                      <FormControl>
-                        <Input type="number" min="1" {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Including themselves, how many people live in the home?
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="hasYard"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        Do they have a yard? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="landlordPermission"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        If they rent, do they have landlord permission? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="hasChildren"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        Are there children in the home? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                {hasChildrenValue === "true" && (
-                  <FormField
-                    control={form.control}
-                    name="childrenAges"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Children&apos;s Ages *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="e.g., 5, 12, 15" {...field} />
-                        </FormControl>
-                        <FormDescription>
-                          Please provide a comma-separated list of ages.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                )}
-              </div>
-              <Separator />
-              <FormField
-                control={form.control}
-                name="otherAnimalsDescription"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Other Animals</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Describe other animals in the home (species, age, temperament, etc.)."
-                        className="resize-y"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            {/* Section 3 — Experience & Intent */}
-            <div className="space-y-8">
-              <h3 className="font-semibold border-b pb-2">
-                Experience &amp; Intent
-              </h3>
-              <FormField
-                control={form.control}
-                name="animalExperience"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Animal Experience *</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Please describe their experience with animals, including past ownership."
-                        className="resize-y min-h-25"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="reasonForAdoption"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Reason for Adoption *</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Why does this person want to adopt at this time?"
-                        className="resize-y min-h-25"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            {/* Shared applicant fields */}
+            <ApplicantFieldsSection
+              control={form.control as unknown as Control<ApplicantFieldValues>}
+              watch={
+                form.watch as unknown as UseFormWatch<ApplicantFieldValues>
+              }
+            />
           </CardContent>
 
           <CardFooter className="flex justify-end space-x-4">
-            <Button asChild variant="outline" type="button" disabled={isPending}>
+            <Button
+              asChild
+              variant="outline"
+              type="button"
+              disabled={isPending}
+            >
               <Link
                 href={
                   callbackUrl ??

--- a/components/dashboard/people-directory/adoption-applications/staff-adoption-application-form.tsx
+++ b/components/dashboard/people-directory/adoption-applications/staff-adoption-application-form.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
+import { useForm, Control, UseFormWatch } from "react-hook-form";
 import { z } from "zod";
 import { ChevronsUpDown, Loader2, X } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
@@ -24,24 +24,11 @@ import {
 } from "@/components/ui/card";
 import {
   Form,
-  FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Separator } from "@/components/ui/separator";
 import {
   Popover,
   PopoverContent,
@@ -65,10 +52,12 @@ import {
 } from "@/app/lib/form-state-types";
 import { PersonForApplicationFormPayload } from "@/app/lib/types";
 import { AnimalSearchResult } from "@/app/lib/data/animals/animal.data";
-import { US_STATES } from "@/app/lib/constants/us-states";
-import { livingSituationOptions } from "@/app/lib/utils/enum-formatter";
-import { toYesNo } from "@/app/lib/utils/form-utils";
+import { toYesNo, buildApplicationFormData } from "@/app/lib/utils/form-utils";
 import { staffCreateAdoptionApplication } from "@/app/lib/actions/adoption-application.actions";
+import {
+  ApplicantFieldsSection,
+  ApplicantFieldValues,
+} from "./applicant-fields-section";
 
 type FormValues = z.infer<typeof StaffAdoptionApplicationFormSchema>;
 
@@ -118,10 +107,9 @@ const StaffAdoptionApplicationForm = ({
     },
   });
 
-  const hasChildrenValue = form.watch("hasChildren");
-
   // Animal search state
-  const [selectedAnimal, setSelectedAnimal] = useState<AnimalSearchResult | null>(null);
+  const [selectedAnimal, setSelectedAnimal] =
+    useState<AnimalSearchResult | null>(null);
   const [animalQuery, setAnimalQuery] = useState(animalSearch);
   const [isAnimalSearchOpen, setIsAnimalSearchOpen] = useState(false);
   const [isSearchPending, startSearchTransition] = useTransition();
@@ -130,7 +118,7 @@ const StaffAdoptionApplicationForm = ({
     startSearchTransition(() => {
       if (query.trim().length >= 2) {
         router.replace(
-          `${pathname}?animalSearch=${encodeURIComponent(query.trim())}`
+          `${pathname}?animalSearch=${encodeURIComponent(query.trim())}`,
         );
       } else {
         router.replace(pathname);
@@ -153,14 +141,8 @@ const StaffAdoptionApplicationForm = ({
   }, [state, form]);
 
   const onSubmit = (data: FormValues) => {
-    const formData = new FormData();
-    Object.entries(data).forEach(([key, value]) => {
-      if (value !== null && value !== undefined) {
-        formData.append(key, value);
-      }
-    });
     startTransition(() => {
-      formAction(formData);
+      formAction(buildApplicationFormData(data));
     });
   };
 
@@ -178,7 +160,7 @@ const StaffAdoptionApplicationForm = ({
           </CardHeader>
 
           <CardContent className="space-y-10">
-            {/* Section 0 — Animal */}
+            {/* Section 0 — Animal (create-only) */}
             <div className="space-y-6">
               <h3 className="font-semibold border-b pb-2">Animal</h3>
               <FormField
@@ -189,8 +171,12 @@ const StaffAdoptionApplicationForm = ({
                     <FormLabel>Animal to Adopt *</FormLabel>
                     {selectedAnimal ? (
                       <div className="flex items-center gap-2">
-                        <Badge variant="secondary" className="text-sm py-1 px-3">
-                          {selectedAnimal.name} &middot; {selectedAnimal.species.name}
+                        <Badge
+                          variant="secondary"
+                          className="text-sm py-1 px-3"
+                        >
+                          {selectedAnimal.name} &middot;{" "}
+                          {selectedAnimal.species.name}
                         </Badge>
                         <Button
                           type="button"
@@ -245,7 +231,9 @@ const StaffAdoptionApplicationForm = ({
                                   Type at least 2 characters to search.
                                 </CommandEmpty>
                               ) : animalResults.length === 0 ? (
-                                <CommandEmpty>No published animals found.</CommandEmpty>
+                                <CommandEmpty>
+                                  No published animals found.
+                                </CommandEmpty>
                               ) : (
                                 <CommandGroup>
                                   {animalResults.map((animal) => (
@@ -279,371 +267,22 @@ const StaffAdoptionApplicationForm = ({
               />
             </div>
 
-            {/* Section 1 — Applicant Information */}
-            <div className="space-y-6">
-              <h3 className="font-semibold border-b pb-2">
-                Applicant Information
-              </h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <FormField
-                  control={form.control}
-                  name="applicantName"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Full Name *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="John Doe" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantEmail"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email *</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="email"
-                          placeholder="you@example.com"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantPhone"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Phone *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="(123) 456-7890" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <Separator />
-              <div className="space-y-6">
-                <FormField
-                  control={form.control}
-                  name="applicantAddressLine1"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Address Line 1 *</FormLabel>
-                      <FormControl>
-                        <Input placeholder="123 Main St" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="applicantAddressLine2"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Address Line 2</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="Apt, Suite, etc. (Optional)"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-                  <FormField
-                    control={form.control}
-                    name="applicantCity"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>City *</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="applicantState"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>State *</FormLabel>
-                        <Select
-                          onValueChange={field.onChange}
-                          defaultValue={field.value}
-                        >
-                          <FormControl>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select a state" />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {US_STATES.map((s) => (
-                              <SelectItem key={s.code} value={s.code}>
-                                {s.name}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="applicantZipCode"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ZIP Code *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="12345" {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-
-            {/* Section 2 — Home & Lifestyle */}
-            <div className="space-y-8">
-              <h3 className="font-semibold border-b pb-2">Home &amp; Lifestyle</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-                <FormField
-                  control={form.control}
-                  name="livingSituation"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Living Situation *</FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        defaultValue={field.value}
-                      >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select living situation" />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {livingSituationOptions.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                              {option.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="householdSize"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Household Size *</FormLabel>
-                      <FormControl>
-                        <Input type="number" min="1" {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Including yourself, how many people live in the home?
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="hasYard"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        Do they have a yard? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="landlordPermission"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        If they rent, do they have landlord permission? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="hasChildren"
-                  render={({ field }) => (
-                    <FormItem className="space-y-3">
-                      <div className="text-sm font-medium">
-                        Are there children in the home? *
-                      </div>
-                      <FormControl>
-                        <RadioGroup
-                          onValueChange={field.onChange}
-                          value={field.value}
-                          className="flex items-center space-x-4"
-                        >
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="true" />
-                            </FormControl>
-                            <FormLabel className="font-normal">Yes</FormLabel>
-                          </FormItem>
-                          <FormItem className="flex items-center space-x-2">
-                            <FormControl>
-                              <RadioGroupItem value="false" />
-                            </FormControl>
-                            <FormLabel className="font-normal">No</FormLabel>
-                          </FormItem>
-                        </RadioGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                {hasChildrenValue === "true" && (
-                  <FormField
-                    control={form.control}
-                    name="childrenAges"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Children&apos;s Ages *</FormLabel>
-                        <FormControl>
-                          <Input placeholder="e.g., 5, 12, 15" {...field} />
-                        </FormControl>
-                        <FormDescription>
-                          Please provide a comma-separated list of ages.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                )}
-              </div>
-              <Separator />
-              <FormField
-                control={form.control}
-                name="otherAnimalsDescription"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Other Animals</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Describe other animals in the home (species, age, temperament, etc.)."
-                        className="resize-y"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            {/* Section 3 — Experience & Intent */}
-            <div className="space-y-8">
-              <h3 className="font-semibold border-b pb-2">
-                Experience &amp; Intent
-              </h3>
-              <FormField
-                control={form.control}
-                name="animalExperience"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Animal Experience *</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Please describe their experience with animals, including past ownership."
-                        className="resize-y min-h-25"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="reasonForAdoption"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Reason for Adoption *</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="Why does this person want to adopt at this time? What are they looking for in a companion?"
-                        className="resize-y min-h-25"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
+            {/* Shared applicant fields */}
+            <ApplicantFieldsSection
+              control={form.control as unknown as Control<ApplicantFieldValues>}
+              watch={
+                form.watch as unknown as UseFormWatch<ApplicantFieldValues>
+              }
+            />
           </CardContent>
 
           <CardFooter className="flex justify-end space-x-4">
-            <Button asChild variant="outline" type="button" disabled={isPending}>
+            <Button
+              asChild
+              variant="outline"
+              type="button"
+              disabled={isPending}
+            >
               <Link
                 href={`/dashboard/people-directory/${person.id}/adoption-applications`}
               >


### PR DESCRIPTION
## What

Extracts the duplicated form-field block shared by the two staff adoption application forms (create + edit) into a single `ApplicantFieldsSection` component.

## Changes

- New `applicant-fields-section.tsx`
- `staff-adoption-application-form.tsx` and `staff-adoption-application-edit-form.tsx` now render the shared section.
- `buildApplicationFormData` added to `form-utils.ts`.
- Normalized the staff forms to consistent third-person wording (fixes the yourself/themselves inconsistency).