### PR TITLE
feat: shelter reporting section (outcomes, intake, length of stay)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,14 @@ POSTGRES_DB="postgres"
 POSTGRES_PORT="5432"
 
 # ==================================
+# === Reporting                  ===
+# ==================================
+# IANA timezone the shelter operates in. All report date-range boundaries are
+# computed in this zone so every viewer sees identical numbers. Defaults to
+# "America/New_York" when unset.
+SHELTER_TIMEZONE="America/New_York"
+
+# ==================================
 # === Demo Setup                 ===
 # ==================================
 # Flag for demo, it will show the demo banner and different 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Add the following variables to your `.env` file. See `.env.example` for a full r
 | ----------------------- | ----------- | ---------------------------------------------------------------- |
 | `BLOB_READ_WRITE_TOKEN` | ✅ Required | Read/write token for Vercel Blob Storage (stores animal images). |
 
+### Reporting
+
+| Variable           | Required    | Description                                                                                                                                         |
+| ------------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SHELTER_TIMEZONE` | ⚪ Optional | IANA timezone the shelter operates in (e.g. `America/New_York`). All report date-range boundaries are computed in this zone. Defaults to `America/New_York`. |
+
 ### Generating `AUTH_SECRET`
 
 Run the following command to generate a secure secret key:

--- a/app/dashboard/reports/error.tsx
+++ b/app/dashboard/reports/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import PageNotFoundOrAccessDenied from '@/components/PageNotFoundOrAccessDenied';
+import { Button } from '@/components/ui/button';
+
+export default function Error({
+  error: _error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const actionButton = (
+    <Button
+      onClick={() => reset()}
+      className="mt-8"
+    >
+      Try again
+    </Button>
+  );
+
+  return (
+    <PageNotFoundOrAccessDenied
+      type="genericError"
+      actionButton={actionButton}
+    />
+  );
+}

--- a/app/dashboard/reports/intakes/loading.tsx
+++ b/app/dashboard/reports/intakes/loading.tsx
@@ -1,0 +1,61 @@
+import { Card, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const Loading = () => {
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Skeleton className="h-4 w-48" />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-52" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-4 w-40" />
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <Skeleton className="h-8 w-44" />
+            <Skeleton className="h-8 w-24" />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="@container/card h-full">
+            <CardHeader>
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="mt-1 h-8 w-20" />
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <Skeleton className="h-[250px] w-full" />
+        </div>
+      </Card>
+
+      {Array.from({ length: 2 }).map((_, i) => (
+        <Card key={i} className="@container/card">
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <div className="flex flex-col gap-3 px-6 pb-6">
+            {Array.from({ length: 4 }).map((_, j) => (
+              <Skeleton key={j} className="h-8 w-full" />
+            ))}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/dashboard/reports/intakes/page.tsx
+++ b/app/dashboard/reports/intakes/page.tsx
@@ -1,0 +1,300 @@
+import Link from "next/link";
+
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { SearchParamsType } from "@/app/lib/types";
+import { ReportParamsSchema } from "@/app/lib/zod-schemas/report.schemas";
+import {
+  formatRangeLabel,
+  resolveReportRange,
+} from "@/app/lib/utils/report-date-utils";
+import { SHELTER_TIMEZONE } from "@/app/lib/constants/constants";
+import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
+import { fetchSpecies } from "@/app/lib/data/animals/animal.data";
+import { fetchIntakeReport } from "@/app/lib/data/reports/intake-report.data";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ReportRangePicker } from "@/components/dashboard/reports/report-range-picker";
+import { IntakeTrendChart } from "@/components/dashboard/reports/intake-trend-chart";
+import type { IntakeReportRow } from "@/app/lib/data/reports/intake-report.data";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  searchParams: SearchParamsType;
+}
+
+/** Builds the overview href, preserving the current range/species params. */
+function overviewHref({
+  from,
+  to,
+  species,
+}: {
+  from?: string;
+  to?: string;
+  species?: string;
+}) {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  if (species) params.set("species", species);
+  const qs = params.toString();
+  return qs ? `/dashboard/reports?${qs}` : "/dashboard/reports";
+}
+
+const Page = async ({ searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.REPORTS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ searchParams }: Props) => {
+  const raw = await searchParams;
+  // Forgiving parse: a mangled URL falls back to the default (year-to-date)
+  // range rather than erroring. The fetcher re-validates independently.
+  const parsed = ReportParamsSchema.safeParse(raw);
+  const { from, to, species } = parsed.success ? parsed.data : {};
+
+  const range = resolveReportRange(from, to);
+  const [speciesList, report] = await Promise.all([
+    fetchSpecies(),
+    fetchIntakeReport(from, to, species),
+  ]);
+  const speciesOptions = speciesList.map((s) => ({
+    label: s.name,
+    value: s.id,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={overviewHref({ from, to, species })}>Reports</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Intake sources</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Intake sources
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Where animals came from and how intakes trended over the selected
+            period.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">{formatRangeLabel(range)}</span>
+          <span className="text-muted-foreground text-xs">
+            · Times counted in {SHELTER_TIMEZONE}
+          </span>
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <ReportRangePicker />
+            <ServerSideFacetedFilter
+              title="Species"
+              paramKey="species"
+              options={speciesOptions}
+            />
+            {/* Room reserved here for a future CSV/PDF export button. */}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-3">
+        <MetricCard label="Total intakes" value={`${report.total}`} />
+        <MetricCard
+          label="Largest source"
+          value={
+            report.largestSource
+              ? formatSingleEnumOption(report.largestSource.type)
+              : "—"
+          }
+          hint={
+            report.largestSource
+              ? `${report.largestSource.count} intake${
+                  report.largestSource.count === 1 ? "" : "s"
+                }`
+              : undefined
+          }
+        />
+        <MetricCard label="Transfers in" value={`${report.transfersIn}`} />
+      </div>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Monthly intake trend</CardTitle>
+          <CardDescription>
+            Total intakes per calendar month over the selected period.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-2 pb-4 sm:px-6 sm:pb-6">
+          <IntakeTrendChart data={report.monthlySeries} />
+        </div>
+      </Card>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Intakes by source type</CardTitle>
+          <CardDescription>
+            Count and share of total for each intake type in the period.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <IntakeBreakdown rows={report.byType} />
+        </div>
+      </Card>
+
+      {report.topPartners.length > 0 && (
+        <Card className="@container/card">
+          <CardHeader>
+            <CardTitle>Top transfer-in partners</CardTitle>
+            <CardDescription>
+              Source partners for transfers in during the period, by count.
+            </CardDescription>
+          </CardHeader>
+          <div className="px-6 pb-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Partner</TableHead>
+                  <TableHead className="text-right">Transfers in</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {report.topPartners.map((partner) => (
+                  <TableRow key={partner.partnerId}>
+                    <TableCell className="font-medium">
+                      {partner.name}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {partner.count}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </Card>
+      )}
+
+      <p className="text-muted-foreground text-xs">
+        Date boundaries computed in {SHELTER_TIMEZONE}; months are calendar
+        months in that zone.
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Intakes-by-type breakdown as a server-rendered horizontal bar list — one row
+ * per intake type present in the period, each showing its share of total
+ * intakes. No client JS required.
+ */
+function IntakeBreakdown({ rows }: { rows: IntakeReportRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No intakes recorded in this period.
+      </p>
+    );
+  }
+
+  // Scale bar widths to the largest slice so the chart uses its full width even
+  // when no single type dominates; the printed percent is always of the total.
+  const maxPercent = Math.max(...rows.map((r) => r.percentOfTotal));
+
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.map((row) => {
+        const percent = row.percentOfTotal * 100;
+        const width =
+          maxPercent > 0 ? (row.percentOfTotal / maxPercent) * 100 : 0;
+        return (
+          <div key={row.type} className="flex flex-col gap-1">
+            <div className="flex items-baseline justify-between gap-2 text-sm">
+              <span className="font-medium">
+                {formatSingleEnumOption(row.type)}
+              </span>
+              <span className="text-muted-foreground tabular-nums">
+                {row.count} · {percent.toFixed(1)}%
+              </span>
+            </div>
+            <div className="bg-muted h-2.5 w-full overflow-hidden rounded-full">
+              <div
+                className="bg-primary h-full rounded-full"
+                style={{ width: `${width}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  hint,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  valueClassName?: string;
+}) {
+  return (
+    <Card className="@container/card h-full">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle
+          className={cn(
+            "text-2xl tabular-nums @[250px]/card:text-3xl",
+            valueClassName,
+          )}
+        >
+          {value}
+        </CardTitle>
+        {hint && (
+          <p className="text-muted-foreground text-xs tabular-nums">{hint}</p>
+        )}
+      </CardHeader>
+    </Card>
+  );
+}
+
+export default Page;

--- a/app/dashboard/reports/length-of-stay/loading.tsx
+++ b/app/dashboard/reports/length-of-stay/loading.tsx
@@ -1,0 +1,59 @@
+import { Card, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const Loading = () => {
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Skeleton className="h-4 w-48" />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-52" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-4 w-40" />
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <Skeleton className="h-8 w-44" />
+            <Skeleton className="h-8 w-24" />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i} className="@container/card h-full">
+            <CardHeader>
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="mt-1 h-8 w-20" />
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-5 w-56" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <Skeleton className="h-[250px] w-full" />
+        </div>
+      </Card>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </CardHeader>
+        <div className="flex flex-col gap-3 px-6 pb-6">
+          {Array.from({ length: 6 }).map((_, j) => (
+            <Skeleton key={j} className="h-8 w-full" />
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/dashboard/reports/length-of-stay/page.tsx
+++ b/app/dashboard/reports/length-of-stay/page.tsx
@@ -1,0 +1,228 @@
+import Link from "next/link";
+
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { SearchParamsType } from "@/app/lib/types";
+import { ReportParamsSchema } from "@/app/lib/zod-schemas/report.schemas";
+import {
+  formatRangeLabel,
+  resolveReportRange,
+} from "@/app/lib/utils/report-date-utils";
+import { SHELTER_TIMEZONE } from "@/app/lib/constants/constants";
+import { fetchSpecies } from "@/app/lib/data/animals/animal.data";
+import { fetchLengthOfStayReport } from "@/app/lib/data/reports/length-of-stay-report.data";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ReportRangePicker } from "@/components/dashboard/reports/report-range-picker";
+import { LosHistogram } from "@/components/dashboard/reports/los-histogram";
+import { LongestStaysTable } from "@/components/dashboard/reports/longest-stays-table";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  searchParams: SearchParamsType;
+}
+
+/** Builds the overview href, preserving the current range/species params. */
+function overviewHref({
+  from,
+  to,
+  species,
+}: {
+  from?: string;
+  to?: string;
+  species?: string;
+}) {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  if (species) params.set("species", species);
+  const qs = params.toString();
+  return qs ? `/dashboard/reports?${qs}` : "/dashboard/reports";
+}
+
+const Page = async ({ searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.REPORTS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ searchParams }: Props) => {
+  const raw = await searchParams;
+  // Forgiving parse: a mangled URL falls back to the default (year-to-date)
+  // range rather than erroring. The fetcher re-validates independently.
+  const parsed = ReportParamsSchema.safeParse(raw);
+  const { from, to, species } = parsed.success ? parsed.data : {};
+
+  const range = resolveReportRange(from, to);
+  const [speciesList, report] = await Promise.all([
+    fetchSpecies(),
+    fetchLengthOfStayReport(from, to, species),
+  ]);
+  const speciesOptions = speciesList.map((s) => ({
+    label: s.name,
+    value: s.id,
+  }));
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={overviewHref({ from, to, species })}>Reports</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Length of stay</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Length of stay
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Completed-stay statistics use the selected period; the waiting list
+            reflects animals in care today.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">{formatRangeLabel(range)}</span>
+          <span className="text-muted-foreground text-xs">
+            · Times counted in {SHELTER_TIMEZONE}
+          </span>
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <ReportRangePicker />
+            <ServerSideFacetedFilter
+              title="Species"
+              paramKey="species"
+              options={speciesOptions}
+            />
+            {/* Room reserved here for a future CSV/PDF export button. */}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+        <MetricCard
+          label="Median days in care"
+          value={report.medianDays === null ? "—" : `${report.medianDays}`}
+          hint="Completed stays in period"
+        />
+        <MetricCard
+          label="Longest completed stay"
+          value={
+            report.longestCompletedDays === null
+              ? "—"
+              : `${report.longestCompletedDays}`
+          }
+          hint="Days, in period"
+        />
+        <MetricCard
+          label="Animals in care now"
+          value={`${report.inCareNow}`}
+          hint="As of today"
+        />
+        <MetricCard
+          label="In care over 90 days"
+          value={`${report.over90}`}
+          hint="As of today"
+          valueClassName={
+            report.over90 > 0 ? "text-amber-600 dark:text-amber-400" : undefined
+          }
+        />
+      </div>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Completed-stay length distribution</CardTitle>
+          <CardDescription>
+            How long animals that left in this period stayed, bucketed by days.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-2 pb-4 sm:px-6 sm:pb-6">
+          <LosHistogram
+            data={report.histogram}
+            completedCount={report.completedCount}
+          />
+        </div>
+      </Card>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Longest current stays</CardTitle>
+          <CardDescription>
+            Animals in care today, longest-waiting first (top 20). Reflects today
+            regardless of the selected period.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <LongestStaysTable rows={report.worklist} />
+        </div>
+      </Card>
+
+      <p className="text-muted-foreground text-xs">
+        Median and histogram cover stays that ended within the selected period. A
+        stay runs from an intake to its next outcome; repeat visits are separate
+        stays; cumulative is the sum of an animal&apos;s stays. Same-day intake and
+        outcome counts as 0 days. In-care status is derived from intake/outcome
+        records. Date boundaries computed in {SHELTER_TIMEZONE}.
+      </p>
+    </div>
+  );
+};
+
+function MetricCard({
+  label,
+  value,
+  hint,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  valueClassName?: string;
+}) {
+  return (
+    <Card className="@container/card h-full">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle
+          className={cn(
+            "text-2xl tabular-nums @[250px]/card:text-3xl",
+            valueClassName,
+          )}
+        >
+          {value}
+        </CardTitle>
+        {hint && (
+          <p className="text-muted-foreground text-xs tabular-nums">{hint}</p>
+        )}
+      </CardHeader>
+    </Card>
+  );
+}
+
+export default Page;

--- a/app/dashboard/reports/outcomes/loading.tsx
+++ b/app/dashboard/reports/outcomes/loading.tsx
@@ -1,0 +1,51 @@
+import { Card, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const Loading = () => {
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Skeleton className="h-4 w-48" />
+
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-52" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Skeleton className="h-4 w-40" />
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <Skeleton className="h-8 w-44" />
+            <Skeleton className="h-8 w-24" />
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Card key={i} className="@container/card h-full">
+            <CardHeader>
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="mt-1 h-8 w-20" />
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+
+      {Array.from({ length: 2 }).map((_, i) => (
+        <Card key={i} className="@container/card">
+          <CardHeader>
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <div className="flex flex-col gap-3 px-6 pb-6">
+            {Array.from({ length: 4 }).map((_, j) => (
+              <Skeleton key={j} className="h-8 w-full" />
+            ))}
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default Loading;

--- a/app/dashboard/reports/outcomes/page.tsx
+++ b/app/dashboard/reports/outcomes/page.tsx
@@ -1,0 +1,259 @@
+import Link from "next/link";
+
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { SearchParamsType } from "@/app/lib/types";
+import { ReportParamsSchema } from "@/app/lib/zod-schemas/report.schemas";
+import {
+  formatRangeLabel,
+  resolveReportRange,
+} from "@/app/lib/utils/report-date-utils";
+import { SHELTER_TIMEZONE } from "@/app/lib/constants/constants";
+import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
+import { fetchSpecies } from "@/app/lib/data/animals/animal.data";
+import { fetchOutcomeReport } from "@/app/lib/data/reports/outcome-report.data";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ReportRangePicker } from "@/components/dashboard/reports/report-range-picker";
+import { OutcomeBreakdown } from "@/components/dashboard/reports/outcome-breakdown";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  searchParams: SearchParamsType;
+}
+
+/** Formats a 0..1 ratio as a 1-decimal percent, or "—" when null. */
+function formatPercent(value: number | null): string {
+  return value === null ? "—" : `${(value * 100).toFixed(1)}%`;
+}
+
+/** Builds the overview href, preserving the current range/species params. */
+function overviewHref({
+  from,
+  to,
+  species,
+}: {
+  from?: string;
+  to?: string;
+  species?: string;
+}) {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  if (species) params.set("species", species);
+  const qs = params.toString();
+  return qs ? `/dashboard/reports?${qs}` : "/dashboard/reports";
+}
+
+const Page = async ({ searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.REPORTS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ searchParams }: Props) => {
+  const raw = await searchParams;
+  // Forgiving parse: a mangled URL falls back to the default (year-to-date)
+  // range rather than erroring. The fetcher re-validates independently.
+  const parsed = ReportParamsSchema.safeParse(raw);
+  const { from, to, species } = parsed.success ? parsed.data : {};
+
+  const range = resolveReportRange(from, to);
+  const [speciesList, report] = await Promise.all([
+    fetchSpecies(),
+    fetchOutcomeReport(from, to, species),
+  ]);
+  const speciesOptions = speciesList.map((s) => ({
+    label: s.name,
+    value: s.id,
+  }));
+
+  const rateIsHigh =
+    report.liveReleaseRate !== null && report.liveReleaseRate >= 0.9;
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href={overviewHref({ from, to, species })}>Reports</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Outcome statistics</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Outcome statistics
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Live release rate and outcome breakdown over the selected period.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">{formatRangeLabel(range)}</span>
+          <span className="text-muted-foreground text-xs">
+            · Times counted in {SHELTER_TIMEZONE}
+          </span>
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <ReportRangePicker />
+            <ServerSideFacetedFilter
+              title="Species"
+              paramKey="species"
+              options={speciesOptions}
+            />
+            {/* Room reserved here for a future CSV/PDF export button. */}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+        <MetricCard
+          label="Live release rate"
+          value={formatPercent(report.liveReleaseRate)}
+          valueClassName={
+            rateIsHigh ? "text-green-600 dark:text-green-400" : undefined
+          }
+        />
+        <MetricCard label="Total outcomes" value={`${report.total}`} />
+        <MetricCard label="Live outcomes" value={`${report.liveCount}`} />
+        <MetricCard label="Non-live outcomes" value={`${report.nonLiveCount}`} />
+      </div>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Outcomes by type</CardTitle>
+          <CardDescription>
+            Count and share of total for each outcome type in the period.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <OutcomeBreakdown rows={report.rows} />
+        </div>
+      </Card>
+
+      <Card className="@container/card">
+        <CardHeader>
+          <CardTitle>Outcome detail</CardTitle>
+          <CardDescription>
+            Percent of live is shown for live-release outcome types only.
+          </CardDescription>
+        </CardHeader>
+        <div className="px-6 pb-6">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Outcome type</TableHead>
+                <TableHead className="text-right">Count</TableHead>
+                <TableHead className="text-right">% of total</TableHead>
+                <TableHead className="text-right">% of live</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {report.rows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={4}
+                    className="text-muted-foreground text-center"
+                  >
+                    No outcomes recorded in this period.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                report.rows.map((row) => (
+                  <TableRow key={row.type}>
+                    <TableCell className="font-medium">
+                      {formatSingleEnumOption(row.type)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {row.count}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatPercent(row.percentOfTotal)}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        "text-right tabular-nums",
+                        !row.isLive && "text-muted-foreground",
+                      )}
+                    >
+                      {row.isLive ? formatPercent(row.percentOfLive) : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </Card>
+
+      <p className="text-muted-foreground text-xs">
+        Live release rate = (adoption + return to owner + transfer out) ÷ total
+        outcomes, following Shelter Animals Count conventions. Euthanized,
+        deceased, and other count as non-live. Date boundaries computed in{" "}
+        {SHELTER_TIMEZONE}.
+      </p>
+    </div>
+  );
+};
+
+function MetricCard({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <Card className="@container/card h-full">
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle
+          className={cn(
+            "text-2xl tabular-nums @[250px]/card:text-3xl",
+            valueClassName,
+          )}
+        >
+          {value}
+        </CardTitle>
+      </CardHeader>
+    </Card>
+  );
+}
+
+export default Page;

--- a/app/dashboard/reports/page.tsx
+++ b/app/dashboard/reports/page.tsx
@@ -1,0 +1,98 @@
+import { Suspense } from "react";
+
+import { Authorize } from "@/components/auth/authorize";
+import PageNotFoundOrAccessDenied from "@/components/PageNotFoundOrAccessDenied";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { SearchParamsType } from "@/app/lib/types";
+import { ReportParamsSchema } from "@/app/lib/zod-schemas/report.schemas";
+import {
+  formatRangeLabel,
+  resolveReportRange,
+} from "@/app/lib/utils/report-date-utils";
+import { SHELTER_TIMEZONE } from "@/app/lib/constants/constants";
+import { fetchSpecies } from "@/app/lib/data/animals/animal.data";
+import { ServerSideFacetedFilter } from "@/components/table-common/server-side-faceted-filter";
+import { ReportRangePicker } from "@/components/dashboard/reports/report-range-picker";
+import {
+  IntakeSourcesCard,
+  IntakeVsOutcomeCard,
+  LengthOfStayCard,
+  OutcomeStatisticsCard,
+  OverviewCardSkeleton,
+} from "@/components/dashboard/reports/overview-cards";
+
+interface Props {
+  searchParams: SearchParamsType;
+}
+
+const Page = async ({ searchParams }: Props) => {
+  return (
+    <Authorize
+      permission={AppPermissions.REPORTS_READ}
+      fallback={<PageNotFoundOrAccessDenied type="accessDenied" />}
+    >
+      <PageContent searchParams={searchParams} />
+    </Authorize>
+  );
+};
+
+const PageContent = async ({ searchParams }: Props) => {
+  const raw = await searchParams;
+  // A mangled URL falls back to the default (year-to-date)
+  const parsed = ReportParamsSchema.safeParse(raw);
+  const { from, to, species } = parsed.success ? parsed.data : {};
+
+  const range = resolveReportRange(from, to);
+  const speciesList = await fetchSpecies();
+  const speciesOptions = speciesList.map((s) => ({
+    label: s.name,
+    value: s.id,
+  }));
+
+  const cardParams = { from, to, species };
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <div className="flex flex-col gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Reports</h1>
+          <p className="text-muted-foreground text-sm">
+            Historical and compliance statistics over a date range you choose.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm font-medium">{formatRangeLabel(range)}</span>
+          <span className="text-muted-foreground text-xs">
+            · Times counted in {SHELTER_TIMEZONE}
+          </span>
+          <div className="flex flex-wrap items-center gap-2 sm:ml-auto">
+            <ReportRangePicker />
+            <ServerSideFacetedFilter
+              title="Species"
+              paramKey="species"
+              options={speciesOptions}
+            />
+            {/* Room reserved here for a future CSV/PDF export button. */}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-4">
+        <Suspense fallback={<OverviewCardSkeleton />}>
+          <OutcomeStatisticsCard {...cardParams} />
+        </Suspense>
+        <Suspense fallback={<OverviewCardSkeleton />}>
+          <IntakeVsOutcomeCard {...cardParams} />
+        </Suspense>
+        <Suspense fallback={<OverviewCardSkeleton />}>
+          <LengthOfStayCard {...cardParams} />
+        </Suspense>
+        <Suspense fallback={<OverviewCardSkeleton />}>
+          <IntakeSourcesCard {...cardParams} />
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default Page;

--- a/app/lib/auth/permissions.ts
+++ b/app/lib/auth/permissions.ts
@@ -1,7 +1,11 @@
 export const AppPermissions = {
   // Dashboard Analytics Permissions
   ANIMAL_READ_ANALYTICS: "animal:read_analytics", // For pet analytics (e.g., on the main dashboard overview)
-  
+
+  // Reporting (historical/compliance statistics)
+  // reports are the historical/compliance surface over a user-selected range.
+  REPORTS_READ: "reports:read",
+
   // Intake Management
   // INTAKE_READ: "intake:read",
   INTAKE_MANAGE: "intake:create",

--- a/app/lib/auth/roles.config.ts
+++ b/app/lib/auth/roles.config.ts
@@ -22,6 +22,7 @@ const volunteerPermissions: readonly AppPermission[] = [
   AppPermissions.ANIMAL_PHOTO_READ,
   AppPermissions.APPLICATIONS_READ,
   AppPermissions.OUTCOMES_READ,
+  AppPermissions.REPORTS_READ,
   AppPermissions.PARTNERS_READ,
   AppPermissions.PERSONS_READ,
 ] as const;

--- a/app/lib/constants/constants.ts
+++ b/app/lib/constants/constants.ts
@@ -8,3 +8,12 @@ export const ALLOWED_MIME_TYPES = [
 
 // Maximum file size for image uploads (5MB)
 export const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+/**
+ * The single IANA timezone the shelter operates in. All reporting date-range
+ * boundaries are computed in this zone so that every viewer sees identical
+ * numbers regardless of their own browser/OS timezone. Configurable via the
+ * `SHELTER_TIMEZONE` env var, with a sensible fallback.
+ */
+export const SHELTER_TIMEZONE =
+  process.env.SHELTER_TIMEZONE || "America/New_York";

--- a/app/lib/data/reports/intake-report.data.ts
+++ b/app/lib/data/reports/intake-report.data.ts
@@ -1,0 +1,196 @@
+import { format, parseISO } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
+
+import { prisma } from "@/app/lib/prisma";
+import { IntakeType } from "@prisma/client";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { resolveReportRange } from "@/app/lib/utils/report-date-utils";
+import { SHELTER_TIMEZONE } from "@/app/lib/constants/constants";
+import { parseSpeciesIds, speciesWhere } from "./report-shared.data";
+
+// Maximum number of source partners listed in the transfers-in table.
+const TOP_PARTNER_LIMIT = 10;
+
+export type IntakeReportRow = {
+  type: IntakeType;
+  count: number;
+  percentOfTotal: number; // 0..1
+};
+
+// One calendar month in the range: `month` is the sort/bucket key, `label` the
+// display string, `count` the number of intakes recorded that month.
+export type MonthlyIntakePoint = {
+  month: string; // "2026-03"
+  label: string; // "Mar 2026"
+  count: number;
+};
+
+export type IntakePartnerRow = {
+  partnerId: string;
+  name: string;
+  count: number;
+};
+
+export type IntakeReport = {
+  total: number;
+  transfersIn: number;
+  // The single largest intake type in the period, or null when empty.
+  largestSource: { type: IntakeType; count: number } | null;
+  // One row per intake type present in the period, ordered by count desc.
+  byType: IntakeReportRow[];
+  // Continuous, zero-filled series from the first to last month of the range.
+  monthlySeries: MonthlyIntakePoint[];
+  // Up to 10 TRANSFER_IN source partners, ordered by count desc. Empty when the
+  // period has no transfers in.
+  topPartners: IntakePartnerRow[];
+  fromLabel: string;
+  toLabel: string;
+};
+
+/**
+ * Continuous list of `"yyyy-MM"` month keys from `fromLabel`'s month through
+ * `toLabel`'s month, inclusive. The labels are already resolved in the shelter
+ * timezone, so their month prefix is the correct calendar month for that zone.
+ */
+function monthKeysInRange(fromLabel: string, toLabel: string): string[] {
+  let [year, month] = fromLabel.slice(0, 7).split("-").map(Number);
+  const [endYear, endMonth] = toLabel.slice(0, 7).split("-").map(Number);
+
+  const keys: string[] = [];
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    keys.push(`${year}-${String(month).padStart(2, "0")}`);
+    month += 1;
+    if (month > 12) {
+      month = 1;
+      year += 1;
+    }
+  }
+  return keys;
+}
+
+/** Display label for a `"yyyy-MM"` month key, e.g. `"Mar 2026"`. */
+function monthLabel(monthKey: string): string {
+  return format(parseISO(`${monthKey}-01`), "MMM yyyy");
+}
+
+/**
+ * Intake statistics for the selected range and species filter: a per-type
+ * breakdown, a month-by-month trend, and the top source partners for transfers
+ * in. Shares its range resolution and `where` shape with the overview intake
+ * card ([[reports-overview.data]]), so the two surfaces always agree on totals.
+ */
+const _fetchIntakeReport = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<IntakeReport> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+    const where = {
+      intakeDate: { gte: range.gte, lt: range.lt },
+      ...speciesWhere(speciesIds),
+    };
+
+    // PERF: fetching bare intake dates for the trend is fine at shelter scale (a
+    // busy shelter is thousands of intakes/year, not millions).
+    const [grouped, intakeDates, partnerGroups] = await Promise.all([
+      prisma.intake.groupBy({
+        by: ["type"],
+        where,
+        _count: { id: true },
+      }),
+      prisma.intake.findMany({
+        where,
+        select: { intakeDate: true },
+      }),
+      prisma.intake.groupBy({
+        by: ["sourcePartnerId"],
+        where: {
+          ...where,
+          type: IntakeType.TRANSFER_IN,
+          sourcePartnerId: { not: null },
+        },
+        _count: { id: true },
+      }),
+    ]);
+
+    const total = grouped.reduce((sum, g) => sum + g._count.id, 0);
+    const transfersIn =
+      grouped.find((g) => g.type === IntakeType.TRANSFER_IN)?._count.id ?? 0;
+
+    const byType: IntakeReportRow[] = grouped
+      .map((g) => ({
+        type: g.type,
+        count: g._count.id,
+        percentOfTotal: total === 0 ? 0 : g._count.id / total,
+      }))
+      .sort((a, b) => b.count - a.count);
+
+    const largestSource =
+      byType.length > 0
+        ? { type: byType[0].type, count: byType[0].count }
+        : null;
+
+    // Bucket intakes by calendar month in the shelter timezone, then emit a
+    // continuous zero-filled series so the chart has no gaps. Grouping by month
+    // in the DB can't express timezone-aware truncation, so we do it in JS.
+    const bucket = new Map<string, number>();
+    for (const { intakeDate } of intakeDates) {
+      const key = formatInTimeZone(intakeDate, SHELTER_TIMEZONE, "yyyy-MM");
+      bucket.set(key, (bucket.get(key) ?? 0) + 1);
+    }
+    const monthlySeries: MonthlyIntakePoint[] = monthKeysInRange(
+      range.fromLabel,
+      range.toLabel,
+    ).map((month) => ({
+      month,
+      label: monthLabel(month),
+      count: bucket.get(month) ?? 0,
+    }));
+
+    // Resolve the top source partners to names with one findMany on ids.
+    const sortedPartners = partnerGroups
+      .filter(
+        (g): g is typeof g & { sourcePartnerId: string } =>
+          g.sourcePartnerId !== null,
+      )
+      .sort((a, b) => b._count.id - a._count.id)
+      .slice(0, TOP_PARTNER_LIMIT);
+
+    const partnerIds = sortedPartners.map((g) => g.sourcePartnerId);
+    const partners =
+      partnerIds.length > 0
+        ? await prisma.partner.findMany({
+            where: { id: { in: partnerIds } },
+            select: { id: true, name: true },
+          })
+        : [];
+    const nameById = new Map(partners.map((p) => [p.id, p.name]));
+
+    const topPartners: IntakePartnerRow[] = sortedPartners.map((g) => ({
+      partnerId: g.sourcePartnerId,
+      name: nameById.get(g.sourcePartnerId) ?? "Unknown partner",
+      count: g._count.id,
+    }));
+
+    return {
+      total,
+      transfersIn,
+      largestSource,
+      byType,
+      monthlySeries,
+      topPartners,
+      fromLabel: range.fromLabel,
+      toLabel: range.toLabel,
+    };
+  } catch (error) {
+    console.error("Error fetching intake report.", error);
+    throw new Error("Error fetching intake report.");
+  }
+};
+
+export const fetchIntakeReport = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchIntakeReport);

--- a/app/lib/data/reports/length-of-stay-report.data.ts
+++ b/app/lib/data/reports/length-of-stay-report.data.ts
@@ -1,0 +1,169 @@
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { resolveReportRange } from "@/app/lib/utils/report-date-utils";
+import { computeStays } from "@/app/lib/utils/stay-utils";
+import { _fetchAnimalStayEvents, parseSpeciesIds } from "./report-shared.data";
+
+// An open stay past this many days is counted as long-staying. Must match the
+// overview card's threshold ([[reports-overview.data]]) so the two agree.
+const LONG_STAY_DAY_THRESHOLD = 90;
+
+// Number of animals shown in the "longest current stays" worklist.
+const WORKLIST_LIMIT = 20;
+
+/** Median of a numeric list, or `null` for an empty list (displays as "—"). */
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// Histogram buckets over completed-stay durations, in render order. Boundaries
+// are inclusive of the upper number except the final open-ended "90+" bucket,
+// which counts stays STRICTLY over 90 days — matching the `over90` threshold so
+// the last bar and the "in care over 90 days" card use the same 90-day line.
+type BucketDef = { label: string; test: (days: number) => boolean };
+const HISTOGRAM_BUCKETS: readonly BucketDef[] = [
+  { label: "0–7", test: (d) => d <= 7 },
+  { label: "8–30", test: (d) => d > 7 && d <= 30 },
+  { label: "31–90", test: (d) => d > 30 && d <= 90 },
+  { label: "90+", test: (d) => d > 90 },
+];
+
+export type LosHistogramBucket = {
+  label: string; // e.g. "0–7"
+  count: number;
+};
+
+export type LongestStayRow = {
+  animalId: string;
+  name: string;
+  speciesName: string;
+  currentStayDays: number;
+  cumulativeDays: number;
+  // True when the animal has returned before, so cumulative > current and the
+  // UI shows the cumulative column; false renders "same"/blank.
+  hasPriorStays: boolean;
+  intakeDate: Date; // intake date of the currently open stay
+};
+
+export type LengthOfStayReport = {
+  // Compliance stats over stays whose OUTCOME fell inside the selected period.
+  medianDays: number | null; // null → no completed stays in range ("—")
+  longestCompletedDays: number | null; // null when no completed stays in range
+  completedCount: number;
+  histogram: LosHistogramBucket[];
+  inCareNow: number; // full in-care count (not the sliced worklist)
+  over90: number; // in-care animals whose open stay exceeds 90 days
+  worklist: LongestStayRow[]; // longest current stays, desc, top 20
+  fromLabel: string;
+  toLabel: string;
+};
+
+/**
+ * Length-of-stay statistics for the selected range and species filter.
+ *
+ * DELIBERATE ASYMMETRY (decision record): the median/max/histogram cover only
+ * completed stays whose outcome fell inside the selected period (the compliance
+ * framing), while the in-care worklist and its counts are always "as of now",
+ * independent of the range. This is intentional — do NOT filter the worklist to
+ * the range to make them symmetric.
+ *
+ * In-care status is derived purely from the intake/outcome pairing
+ * ([[stay-utils]]), never from `listingStatus`, so animals that are DRAFT or
+ * ARCHIVED but physically present still count.
+ */
+const _fetchLengthOfStayReport = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<LengthOfStayReport> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+    const now = new Date();
+
+    // PERF: this walks every animal's full intake/outcome history in memory
+    // (O(animals)). Acceptable at current shelter scale. Optimization candidate:
+    // the completed-stay stats could restrict the fetch to animals with an
+    // outcome in range, but the worklist still needs all in-care animals — so a
+    // future rollup/stay table is the cleaner win than a narrower fetch here.
+    const animals = await _fetchAnimalStayEvents(speciesIds);
+
+    const completedStayDays: number[] = [];
+    const inCareRows: LongestStayRow[] = [];
+
+    for (const animal of animals) {
+      const { stays, isInCare, currentStayDays, cumulativeDays } = computeStays(
+        animal.events,
+        now,
+      );
+
+      // Compliance stats: every completed stay whose outcome falls in-range.
+      // An animal may contribute more than one stay.
+      for (const stay of stays) {
+        if (
+          stay.outcomeDate &&
+          stay.outcomeDate >= range.gte &&
+          stay.outcomeDate < range.lt
+        ) {
+          completedStayDays.push(stay.days);
+        }
+      }
+
+      // Worklist: current open stay, always as of now.
+      if (isInCare) {
+        const openStay = stays[stays.length - 1];
+        inCareRows.push({
+          animalId: animal.id,
+          name: animal.name,
+          speciesName: animal.speciesName,
+          currentStayDays: currentStayDays ?? 0,
+          cumulativeDays,
+          hasPriorStays: cumulativeDays !== (currentStayDays ?? 0),
+          intakeDate: openStay.intakeDate,
+        });
+      }
+    }
+
+    const histogram: LosHistogramBucket[] = HISTOGRAM_BUCKETS.map((bucket) => ({
+      label: bucket.label,
+      count: completedStayDays.filter((days) => bucket.test(days)).length,
+    }));
+
+    // Sort the full in-care set before slicing, but derive the counts from the
+    // unsliced set so they reflect every in-care animal, not just the top 20.
+    inCareRows.sort(
+      (a, b) =>
+        b.currentStayDays - a.currentStayDays ||
+        b.cumulativeDays - a.cumulativeDays ||
+        a.name.localeCompare(b.name),
+    );
+    const over90 = inCareRows.filter(
+      (row) => row.currentStayDays > LONG_STAY_DAY_THRESHOLD,
+    ).length;
+
+    return {
+      medianDays: median(completedStayDays),
+      longestCompletedDays:
+        completedStayDays.length === 0 ? null : Math.max(...completedStayDays),
+      completedCount: completedStayDays.length,
+      histogram,
+      inCareNow: inCareRows.length,
+      over90,
+      worklist: inCareRows.slice(0, WORKLIST_LIMIT),
+      fromLabel: range.fromLabel,
+      toLabel: range.toLabel,
+    };
+  } catch (error) {
+    console.error("Error fetching length of stay report.", error);
+    throw new Error("Error fetching length of stay report.");
+  }
+};
+
+export const fetchLengthOfStayReport = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchLengthOfStayReport);

--- a/app/lib/data/reports/outcome-report.data.ts
+++ b/app/lib/data/reports/outcome-report.data.ts
@@ -1,0 +1,110 @@
+import { prisma } from "@/app/lib/prisma";
+import { OutcomeType } from "@prisma/client";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { resolveReportRange } from "@/app/lib/utils/report-date-utils";
+import {
+  isLiveOutcome,
+  LIVE_OUTCOME_TYPES,
+  parseSpeciesIds,
+  speciesWhere,
+} from "./report-shared.data";
+
+// Display/render order for the breakdown and table: live types first (in the
+// canonical Shelter Animals Count order), then the non-live types. Types with
+// zero outcomes in the period are omitted by the fetcher, so the UI renders a
+// subset of this list, always in this order.
+const OUTCOME_TYPE_ORDER: readonly OutcomeType[] = [
+  ...LIVE_OUTCOME_TYPES, // ADOPTION, RETURN_TO_OWNER, TRANSFER_OUT
+  OutcomeType.EUTHANIZED,
+  OutcomeType.DECEASED,
+  OutcomeType.OTHER,
+];
+
+export type OutcomeReportRow = {
+  type: OutcomeType;
+  count: number;
+  isLive: boolean;
+  percentOfTotal: number; // 0..1
+  percentOfLive: number | null; // 0..1 for live types; null for non-live
+};
+
+export type OutcomeReport = {
+  total: number;
+  liveCount: number;
+  nonLiveCount: number;
+  // 0..1, or null when there are no outcomes in the period (renders as "—").
+  liveReleaseRate: number | null;
+  // One row per outcome type present in the period, ordered live-first. Empty
+  // when the period has no outcomes.
+  rows: OutcomeReportRow[];
+  fromLabel: string;
+  toLabel: string;
+};
+
+/**
+ * Outcome statistics for the selected range and species filter: the live
+ * release rate plus a per-type breakdown. This is the compliance anchor — it
+ * shares its range resolution and live-outcome definition with the overview
+ * card ([[reports-overview.data]]), so the two surfaces always agree.
+ */
+const _fetchOutcomeReport = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<OutcomeReport> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+
+    const grouped = await prisma.outcome.groupBy({
+      by: ["type"],
+      where: {
+        outcomeDate: { gte: range.gte, lt: range.lt },
+        ...speciesWhere(speciesIds),
+      },
+      _count: { id: true },
+    });
+
+    const countByType = new Map<OutcomeType, number>(
+      grouped.map((g) => [g.type, g._count.id]),
+    );
+
+    const total = grouped.reduce((sum, g) => sum + g._count.id, 0);
+    const liveCount = grouped
+      .filter((g) => isLiveOutcome(g.type))
+      .reduce((sum, g) => sum + g._count.id, 0);
+    const nonLiveCount = total - liveCount;
+
+    const rows: OutcomeReportRow[] = OUTCOME_TYPE_ORDER.filter((type) =>
+      countByType.has(type),
+    ).map((type) => {
+      const count = countByType.get(type) ?? 0;
+      const live = isLiveOutcome(type);
+      return {
+        type,
+        count,
+        isLive: live,
+        percentOfTotal: total === 0 ? 0 : count / total,
+        percentOfLive: live && liveCount > 0 ? count / liveCount : live ? 0 : null,
+      };
+    });
+
+    return {
+      total,
+      liveCount,
+      nonLiveCount,
+      liveReleaseRate: total === 0 ? null : liveCount / total,
+      rows,
+      fromLabel: range.fromLabel,
+      toLabel: range.toLabel,
+    };
+  } catch (error) {
+    console.error("Error fetching outcome report.", error);
+    throw new Error("Error fetching outcome report.");
+  }
+};
+
+export const fetchOutcomeReport = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchOutcomeReport);

--- a/app/lib/data/reports/report-shared.data.ts
+++ b/app/lib/data/reports/report-shared.data.ts
@@ -1,0 +1,107 @@
+import { prisma } from "@/app/lib/prisma";
+import { OutcomeType } from "@prisma/client";
+import { type StayEvent } from "@/app/lib/utils/stay-utils";
+import { cuidSchema } from "@/app/lib/zod-schemas/common.schemas";
+
+/**
+ * Live outcomes per Shelter Animals Count conventions: an animal that left the
+ * shelter alive. EUTHANIZED, DECEASED, and OTHER are non-live. This single
+ * definition is the source of truth for both the overview card and the outcomes
+ * detail report, so their numbers can never drift apart.
+ */
+export const LIVE_OUTCOME_TYPES: readonly OutcomeType[] = [
+  OutcomeType.ADOPTION,
+  OutcomeType.RETURN_TO_OWNER,
+  OutcomeType.TRANSFER_OUT,
+];
+
+/** True when a given outcome type counts toward the live release rate. */
+export function isLiveOutcome(type: OutcomeType): boolean {
+  return LIVE_OUTCOME_TYPES.includes(type);
+}
+
+/**
+ * Splits the raw `species` URL param into validated cuid2 ids, silently
+ * dropping any that are malformed. Returns `undefined` when no valid id
+ * remains, which the callers treat as "all species" (no filter).
+ */
+export function parseSpeciesIds(species?: string): string[] | undefined {
+  if (!species) return undefined;
+  const ids = species
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && cuidSchema.safeParse(s).success);
+  return ids.length > 0 ? ids : undefined;
+}
+
+/** Prisma `animal` relation filter for a species subset, or `{}` for all. */
+export function speciesWhere(speciesIds: string[] | undefined): {
+  animal?: { speciesId: { in: string[] } };
+} {
+  return speciesIds ? { animal: { speciesId: { in: speciesIds } } } : {};
+}
+
+/**
+ * One animal plus its full intake/outcome history flattened into `StayEvent[]`,
+ * ready to feed into `computeStays`. The select is deliberately minimal — this
+ * powers length-of-stay and in-care counts and must not drag along images,
+ * notes, etc.
+ */
+export type AnimalStayEvents = {
+  id: string;
+  name: string;
+  speciesId: string;
+  speciesName: string;
+  events: StayEvent[];
+};
+
+/**
+ * Fetches animals with their intake/outcome events mapped to `StayEvent[]`,
+ * optionally filtered by species ids.
+ *
+ * PRIVATE building block: intentionally NOT wrapped with `RequirePermission`.
+ * It must only ever be called from within a permission-wrapped report fetcher
+ * (which is responsible for the `REPORTS_READ` check and for validating the
+ * species ids passed in here).
+ */
+export const _fetchAnimalStayEvents = async (
+  speciesIds?: string[],
+): Promise<AnimalStayEvents[]> => {
+  try {
+    const animals = await prisma.animal.findMany({
+      where:
+        speciesIds && speciesIds.length > 0
+          ? { speciesId: { in: speciesIds } }
+          : undefined,
+      select: {
+        id: true,
+        name: true,
+        speciesId: true,
+        species: { select: { name: true } },
+        intake: { select: { intakeDate: true } },
+        Outcome: { select: { outcomeDate: true } },
+      },
+    });
+
+    return animals.map((animal) => ({
+      id: animal.id,
+      name: animal.name,
+      speciesId: animal.speciesId,
+      speciesName: animal.species.name,
+      events: [
+        ...animal.intake.map(
+          (intake): StayEvent => ({ kind: "intake", date: intake.intakeDate }),
+        ),
+        ...animal.Outcome.map(
+          (outcome): StayEvent => ({
+            kind: "outcome",
+            date: outcome.outcomeDate,
+          }),
+        ),
+      ],
+    }));
+  } catch (error) {
+    console.error("Error fetching animal stay events.", error);
+    throw new Error("Error fetching animal stay events.");
+  }
+};

--- a/app/lib/data/reports/reports-overview.data.ts
+++ b/app/lib/data/reports/reports-overview.data.ts
@@ -1,0 +1,222 @@
+import { prisma } from "@/app/lib/prisma";
+import { IntakeType, OutcomeType } from "@prisma/client";
+import { AppPermissions } from "@/app/lib/auth/permissions";
+import { RequirePermission } from "../../auth/protected-actions";
+import { resolveReportRange } from "@/app/lib/utils/report-date-utils";
+import { computeStays } from "@/app/lib/utils/stay-utils";
+import {
+  _fetchAnimalStayEvents,
+  isLiveOutcome,
+  parseSpeciesIds,
+  speciesWhere,
+} from "./report-shared.data";
+
+// An in-care stay past this many days is flagged as long-staying on the card.
+const LONG_STAY_DAY_THRESHOLD = 90;
+
+/** Median of a numeric list, or `null` for an empty list (displays as "—"). */
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+// ---------------------------------------------------------------------------
+// Outcome statistics — live release rate + top outcome types.
+// ---------------------------------------------------------------------------
+
+export type OutcomeSummary = {
+  total: number;
+  liveCount: number;
+  liveReleaseRate: number; // 0..1; 0 when there are no outcomes (never NaN)
+  topTypes: { type: OutcomeType; count: number }[]; // up to 3, desc by count
+};
+
+const _fetchOutcomeSummary = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<OutcomeSummary> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+
+    const grouped = await prisma.outcome.groupBy({
+      by: ["type"],
+      where: {
+        outcomeDate: { gte: range.gte, lt: range.lt },
+        ...speciesWhere(speciesIds),
+      },
+      _count: { id: true },
+    });
+
+    const counts = grouped.map((g) => ({ type: g.type, count: g._count.id }));
+    const total = counts.reduce((sum, c) => sum + c.count, 0);
+    const liveCount = counts
+      .filter((c) => isLiveOutcome(c.type))
+      .reduce((sum, c) => sum + c.count, 0);
+    const liveReleaseRate = total === 0 ? 0 : liveCount / total;
+    const topTypes = [...counts]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 3);
+
+    return { total, liveCount, liveReleaseRate, topTypes };
+  } catch (error) {
+    console.error("Error fetching outcome summary.", error);
+    throw new Error("Error fetching outcome summary.");
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Intake sources — total intakes + top intake types.
+// ---------------------------------------------------------------------------
+
+export type IntakeSummary = {
+  total: number;
+  topTypes: { type: IntakeType; count: number }[]; // up to 2, desc by count
+};
+
+const _fetchIntakeSummary = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<IntakeSummary> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+
+    const grouped = await prisma.intake.groupBy({
+      by: ["type"],
+      where: {
+        intakeDate: { gte: range.gte, lt: range.lt },
+        ...speciesWhere(speciesIds),
+      },
+      _count: { id: true },
+    });
+
+    const counts = grouped.map((g) => ({ type: g.type, count: g._count.id }));
+    const total = counts.reduce((sum, c) => sum + c.count, 0);
+    const topTypes = [...counts]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 2);
+
+    return { total, topTypes };
+  } catch (error) {
+    console.error("Error fetching intake summary.", error);
+    throw new Error("Error fetching intake summary.");
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Intake vs outcome balance — in / out / net over the period.
+// ---------------------------------------------------------------------------
+
+export type BalanceSummary = {
+  intakes: number;
+  outcomes: number;
+  net: number; // intakes − outcomes (positive = net growth in care)
+};
+
+const _fetchBalanceSummary = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<BalanceSummary> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+    const filter = speciesWhere(speciesIds);
+
+    const [intakes, outcomes] = await Promise.all([
+      prisma.intake.count({
+        where: { intakeDate: { gte: range.gte, lt: range.lt }, ...filter },
+      }),
+      prisma.outcome.count({
+        where: { outcomeDate: { gte: range.gte, lt: range.lt }, ...filter },
+      }),
+    ]);
+
+    return { intakes, outcomes, net: intakes - outcomes };
+  } catch (error) {
+    console.error("Error fetching balance summary.", error);
+    throw new Error("Error fetching balance summary.");
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Length of stay — median of completed stays + in-care worklist counts.
+// ---------------------------------------------------------------------------
+
+export type LengthOfStaySummary = {
+  medianDays: number | null; // null → no completed stays in range ("—")
+  inCareNow: number;
+  over90: number; // in-care animals whose current stay exceeds 90 days
+};
+
+const _fetchLengthOfStaySummary = async (
+  from?: string,
+  to?: string,
+  species?: string,
+): Promise<LengthOfStaySummary> => {
+  try {
+    const range = resolveReportRange(from, to);
+    const speciesIds = parseSpeciesIds(species);
+    const now = new Date();
+
+    // PERF: this walks every animal's full intake/outcome history in memory
+    // (O(animals)). Acceptable at current shelter scale; if the animal count
+    // grows large, promote this to a precomputed stay table or a SQL rollup.
+    const animals = await _fetchAnimalStayEvents(speciesIds);
+
+    const completedStayDays: number[] = [];
+    let inCareNow = 0;
+    let over90 = 0;
+
+    for (const animal of animals) {
+      const { stays, isInCare, currentStayDays } = computeStays(
+        animal.events,
+        now,
+      );
+
+      // Headline median counts completed stays whose outcome falls in-range.
+      for (const stay of stays) {
+        if (
+          stay.outcomeDate &&
+          stay.outcomeDate >= range.gte &&
+          stay.outcomeDate < range.lt
+        ) {
+          completedStayDays.push(stay.days);
+        }
+      }
+
+      if (isInCare) {
+        inCareNow += 1;
+        if ((currentStayDays ?? 0) > LONG_STAY_DAY_THRESHOLD) over90 += 1;
+      }
+    }
+
+    return { medianDays: median(completedStayDays), inCareNow, over90 };
+  } catch (error) {
+    console.error("Error fetching length of stay summary.", error);
+    throw new Error("Error fetching length of stay summary.");
+  }
+};
+
+export const fetchOutcomeSummary = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchOutcomeSummary);
+
+export const fetchIntakeSummary = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchIntakeSummary);
+
+export const fetchBalanceSummary = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchBalanceSummary);
+
+export const fetchLengthOfStaySummary = RequirePermission(
+  AppPermissions.REPORTS_READ,
+)(_fetchLengthOfStaySummary);

--- a/app/lib/utils/report-date-utils.ts
+++ b/app/lib/utils/report-date-utils.ts
@@ -1,0 +1,102 @@
+// Report date boundaries are computed in a single configured timezone
+// (SHELTER_TIMEZONE). Timestamps are stored in UTC, but a shelter's "June"
+// means June in the shelter's local days — so every report boundary is resolved
+// in one configured zone. This guarantees all viewers see identical numbers
+// regardless of their own browser/OS timezone.
+
+import { format, differenceInCalendarDays, isValid, parseISO } from "date-fns";
+import { fromZonedTime, formatInTimeZone } from "date-fns-tz";
+import { SHELTER_TIMEZONE } from "../constants/constants";
+
+// Widest window a report may cover; wider requests are clamped, never errored.
+const MAX_RANGE_DAYS = 731;
+
+export type ReportRange = {
+  gte: Date; // UTC instant: start of `from` day in shelter tz
+  lt: Date; // UTC instant: start of the day AFTER `to` in shelter tz (exclusive)
+  fromLabel: string; // "yyyy-MM-dd" actually used (after defaults/clamping)
+  toLabel: string;
+};
+
+/** Today's date as `yyyy-MM-dd`, reckoned in the shelter timezone. */
+function todayLabel(): string {
+  return formatInTimeZone(new Date(), SHELTER_TIMEZONE, "yyyy-MM-dd");
+}
+
+/** January 1 of the current shelter-timezone year, as `yyyy-MM-dd`. */
+function startOfYearLabel(): string {
+  const year = formatInTimeZone(new Date(), SHELTER_TIMEZONE, "yyyy");
+  return `${year}-01-01`;
+}
+
+/**
+ * Parses a `yyyy-MM-dd` string into a plain calendar Date (local midnight, used
+ * only for day arithmetic/labeling), returning null if absent, malformed, or a
+ * non-existent calendar date (e.g. "2026-02-30").
+ */
+function parseLabel(value: string | undefined): Date | null {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = parseISO(value);
+  if (!isValid(parsed)) return null;
+  // Reject roll-over dates: the round-tripped label must match the input.
+  if (format(parsed, "yyyy-MM-dd") !== value) return null;
+  return parsed;
+}
+
+/** The UTC instant at which `yyyy-MM-dd` begins (midnight) in the shelter tz. */
+function zonedDayStart(label: string): Date {
+  return fromZonedTime(`${label} 00:00:00`, SHELTER_TIMEZONE);
+}
+
+function addDaysLabel(label: string, days: number): string {
+  const d = parseISO(label);
+  d.setDate(d.getDate() + days);
+  return format(d, "yyyy-MM-dd");
+}
+
+/**
+ * Resolves raw `from`/`to` URL params into a concrete, timezone-anchored range.
+ *
+ *  - Missing `to` → today; missing `from` → Jan 1 of the current year (YTD).
+ *  - `from > to` is swapped rather than errored.
+ *  - Spans wider than 731 days clamp `from` to `to - 731 days`.
+ *  - Unparseable input falls back to the defaults; this function never throws.
+ *
+ * The returned `gte`/`lt` are UTC instants ready for Prisma; `lt` is exclusive
+ * (start of the day after `to`) so no event is double-counted at midnight.
+ */
+export function resolveReportRange(from?: string, to?: string): ReportRange {
+  let fromLabel = parseLabel(from) ? from! : startOfYearLabel();
+  let toLabel = parseLabel(to) ? to! : todayLabel();
+
+  // Swap reversed ranges.
+  if (fromLabel > toLabel) {
+    [fromLabel, toLabel] = [toLabel, fromLabel];
+  }
+
+  // Clamp overly wide windows, holding `to` fixed.
+  if (differenceInCalendarDays(parseISO(toLabel), parseISO(fromLabel)) > MAX_RANGE_DAYS) {
+    fromLabel = addDaysLabel(toLabel, -MAX_RANGE_DAYS);
+  }
+
+  return {
+    gte: zonedDayStart(fromLabel),
+    lt: zonedDayStart(addDaysLabel(toLabel, 1)),
+    fromLabel,
+    toLabel,
+  };
+}
+
+/**
+ * Human-readable label for a range, e.g. `"Jan 1 – Jul 4, 2026"`. When the two
+ * dates fall in different years the year is shown on both ends.
+ */
+export function formatRangeLabel(range: ReportRange): string {
+  const fromDate = parseISO(range.fromLabel);
+  const toDate = parseISO(range.toLabel);
+  const sameYear = fromDate.getFullYear() === toDate.getFullYear();
+
+  const fromStr = format(fromDate, sameYear ? "MMM d" : "MMM d, yyyy");
+  const toStr = format(toDate, "MMM d, yyyy");
+  return `${fromStr} – ${toStr}`;
+}

--- a/app/lib/utils/stay-utils.ts
+++ b/app/lib/utils/stay-utils.ts
@@ -1,0 +1,88 @@
+// Pure stay-pairing logic — no Prisma imports, so it is trivially unit-testable
+// and reusable. This is the SINGLE SOURCE OF TRUTH for whether an animal is "in
+// care": presence is derived by pairing Intake and Outcome events, never from
+// `listingStatus` (which is about public visibility, not physical presence).
+
+import { differenceInCalendarDays } from "date-fns";
+
+export type StayEvent = { kind: "intake" | "outcome"; date: Date };
+
+export type Stay = {
+  intakeDate: Date;
+  outcomeDate: Date | null; // null = still open
+  days: number; // completed: calendar days between intake and outcome;
+  // open: calendar days between intake and `asOf`
+};
+
+export type StayComputation = {
+  stays: Stay[]; // chronological
+  isInCare: boolean; // true iff last stay is open
+  currentStayDays: number | null; // days of the open stay, else null
+  cumulativeDays: number; // sum of all stay days (closed + open)
+};
+
+/** Calendar-day span, floored at 0 (a same-day intake/outcome is 0 days). */
+function spanDays(from: Date, to: Date): number {
+  return Math.max(0, differenceInCalendarDays(to, from));
+}
+
+/**
+ * Pairs one animal's intake/outcome events into discrete stays.
+ *
+ * Algorithm:
+ *  1. Sort events ascending by date. On equal timestamps, outcomes sort before
+ *     intakes (so a same-instant outcome-then-re-intake is handled correctly).
+ *  2. Walk with a single open-intake pointer:
+ *     - intake, no stay open  → open a stay at that date.
+ *     - intake, stay open     → ignore (duplicate/erroneous entry; the animal
+ *                               never physically left, so the original date stands).
+ *     - outcome, stay open    → close the stay at that date.
+ *     - outcome, no stay open → ignore (orphan record with no matching entry).
+ *  3. `days` uses calendar-day differences, negatives clamped to 0.
+ *  4. `isInCare` is true iff the walk ends with an open stay.
+ */
+export function computeStays(events: StayEvent[], asOf: Date): StayComputation {
+  // outcome (0) before intake (1) on ties.
+  const kindRank = (kind: StayEvent["kind"]) => (kind === "outcome" ? 0 : 1);
+  const sorted = [...events].sort((a, b) => {
+    const byDate = a.date.getTime() - b.date.getTime();
+    return byDate !== 0 ? byDate : kindRank(a.kind) - kindRank(b.kind);
+  });
+
+  const stays: Stay[] = [];
+  let openIntake: Date | null = null;
+
+  for (const event of sorted) {
+    if (event.kind === "intake") {
+      if (openIntake === null) {
+        openIntake = event.date;
+      }
+      // else: duplicate intake while already in care — ignore.
+    } else {
+      if (openIntake !== null) {
+        stays.push({
+          intakeDate: openIntake,
+          outcomeDate: event.date,
+          days: spanDays(openIntake, event.date),
+        });
+        openIntake = null;
+      }
+      // else: orphan outcome — ignore.
+    }
+  }
+
+  // A trailing open intake is the current (still-in-care) stay.
+  if (openIntake !== null) {
+    stays.push({
+      intakeDate: openIntake,
+      outcomeDate: null,
+      days: spanDays(openIntake, asOf),
+    });
+  }
+
+  const isInCare = stays.length > 0 && stays[stays.length - 1].outcomeDate === null;
+  const currentStayDays = isInCare ? stays[stays.length - 1].days : null;
+  const cumulativeDays = stays.reduce((sum, stay) => sum + stay.days, 0);
+
+  return { stays, isInCare, currentStayDays, cumulativeDays };
+}

--- a/app/lib/zod-schemas/report.schemas.ts
+++ b/app/lib/zod-schemas/report.schemas.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * Shared URL search params for every report surface: the date-range window
+ * (`from`/`to` as `yyyy-MM-dd`) and the optional comma-joined species facet.
+ *
+ * Fetchers `safeParse` these and fall back to defaults on failure rather than
+ * throwing — reports should be forgiving of a mangled URL. Individual species
+ * ids are split and validated with `cuidSchema`, silently dropping invalid ones.
+ */
+export const ReportParamsSchema = z.object({
+  from: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  to: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  species: z.string().max(200).optional(), // comma-joined cuid2 species ids
+});
+
+export type ReportParams = z.infer<typeof ReportParamsSchema>;

--- a/components/dashboard/nav/nav-links.config.ts
+++ b/components/dashboard/nav/nav-links.config.ts
@@ -93,6 +93,12 @@ export const navMainItems: readonly NavItem[] = [
     permission: AppPermissions.OUTCOMES_READ,
   },
   {
+    title: "Reports",
+    url: "/dashboard/reports",
+    icon: "IconReport",
+    permission: AppPermissions.REPORTS_READ,
+  },
+  {
     title: "Animal Tasks",
     url: "/dashboard/animal-tasks",
     icon: "IconCheckbox",
@@ -162,10 +168,4 @@ export const navSecondaryItems: readonly NavItem[] = [
 ] as const;
 
 // Documents/Quick actions
-export const documentItems: readonly NavDocument[] = [
-  {
-    name: "Reports",
-    url: "#",
-    icon: "IconReport",
-  },
-] as const;
+export const documentItems: readonly NavDocument[] = [] as const;

--- a/components/dashboard/reports/intake-trend-chart.tsx
+++ b/components/dashboard/reports/intake-trend-chart.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import type { MonthlyIntakePoint } from "@/app/lib/data/reports/intake-report.data";
+
+const chartConfig = {
+  count: {
+    label: "Intakes",
+    color: "hsl(var(--chart-1))",
+  },
+} satisfies ChartConfig;
+
+/**
+ * Monthly intake trend as a single-series bar chart. The data is a continuous,
+ * zero-filled month series computed server-side in the shelter timezone, so the
+ * chart renders every calendar month in the range even when some have no
+ * intakes. Follows the `chart-area-interactive` ChartContainer/tooltip pattern.
+ */
+export function IntakeTrendChart({ data }: { data: MonthlyIntakePoint[] }) {
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className="aspect-auto h-[250px] w-full"
+    >
+      <BarChart data={data} margin={{ left: 12, right: 12 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator="dot" />}
+        />
+        <Bar dataKey="count" fill="var(--color-count)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/components/dashboard/reports/longest-stays-table.tsx
+++ b/components/dashboard/reports/longest-stays-table.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+
+import type { LongestStayRow } from "@/app/lib/data/reports/length-of-stay-report.data";
+import { formatDateOrNA } from "@/app/lib/utils/date-utils";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+/**
+ * The "longest current stays" worklist — animals in care now, ordered by their
+ * current open-stay duration. Server-rendered plain shadcn table; the operational
+ * payoff of the report. The cumulative column is only meaningful for animals
+ * that have returned (prior stays), so it shows "same" otherwise.
+ */
+export function LongestStaysTable({ rows }: { rows: LongestStayRow[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Animal</TableHead>
+          <TableHead>Species</TableHead>
+          <TableHead className="text-right">Current stay (days)</TableHead>
+          <TableHead className="text-right">Cumulative (days)</TableHead>
+          <TableHead>Intake date</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.length === 0 ? (
+          <TableRow>
+            <TableCell
+              colSpan={5}
+              className="text-muted-foreground text-center"
+            >
+              No animals are currently in care.
+            </TableCell>
+          </TableRow>
+        ) : (
+          rows.map((row) => (
+            <TableRow key={row.animalId}>
+              <TableCell className="font-medium">
+                <Link
+                  href={`/dashboard/animals/${row.animalId}`}
+                  className="hover:underline"
+                >
+                  {row.name}
+                </Link>
+              </TableCell>
+              <TableCell>{row.speciesName}</TableCell>
+              <TableCell className="text-right tabular-nums">
+                {row.currentStayDays}
+              </TableCell>
+              <TableCell className="text-muted-foreground text-right tabular-nums">
+                {row.hasPriorStays ? row.cumulativeDays : "same"}
+              </TableCell>
+              <TableCell>{formatDateOrNA(row.intakeDate)}</TableCell>
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  );
+}

--- a/components/dashboard/reports/los-histogram.tsx
+++ b/components/dashboard/reports/los-histogram.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import type { LosHistogramBucket } from "@/app/lib/data/reports/length-of-stay-report.data";
+
+const chartConfig = {
+  count: {
+    label: "Stays",
+    color: "hsl(var(--chart-1))",
+  },
+} satisfies ChartConfig;
+
+/**
+ * Distribution of completed-stay durations across day buckets, as a single-
+ * series bar chart. Buckets and their counts are computed server-side over
+ * stays whose outcome fell inside the selected period. Renders an empty state
+ * when there are no completed stays in range (`completedCount === 0`), since
+ * every bar would be zero. Follows the `intake-trend-chart` ChartContainer
+ * pattern.
+ */
+export function LosHistogram({
+  data,
+  completedCount,
+}: {
+  data: LosHistogramBucket[];
+  completedCount: number;
+}) {
+  if (completedCount === 0) {
+    return (
+      <p className="text-muted-foreground py-8 text-center text-sm">
+        No completed stays in this period.
+      </p>
+    );
+  }
+
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className="aspect-auto h-[250px] w-full"
+    >
+      <BarChart data={data} margin={{ left: 12, right: 12 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={32}
+          allowDecimals={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={
+            <ChartTooltipContent
+              indicator="dot"
+              labelFormatter={(label) => `${label} days`}
+            />
+          }
+        />
+        <Bar dataKey="count" fill="var(--color-count)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/components/dashboard/reports/outcome-breakdown.tsx
+++ b/components/dashboard/reports/outcome-breakdown.tsx
@@ -1,0 +1,71 @@
+import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
+import { cn } from "@/lib/utils";
+import type { OutcomeReportRow } from "@/app/lib/data/reports/outcome-report.data";
+
+/**
+ * Outcomes-by-type breakdown as a server-rendered horizontal bar list — one row
+ * per outcome type present in the period, each showing its share of total
+ * outcomes. Live and non-live types are drawn in two colors (see the legend) so
+ * the live-vs-non-live split reads at a glance without any client JS.
+ */
+export function OutcomeBreakdown({ rows }: { rows: OutcomeReportRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        No outcomes recorded in this period.
+      </p>
+    );
+  }
+
+  // Scale bar widths to the largest slice so the chart uses its full width even
+  // when no single type dominates; the printed percent is always of the total.
+  const maxPercent = Math.max(...rows.map((r) => r.percentOfTotal));
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        {rows.map((row) => {
+          const percent = row.percentOfTotal * 100;
+          const width = maxPercent > 0 ? (row.percentOfTotal / maxPercent) * 100 : 0;
+          return (
+            <div key={row.type} className="flex flex-col gap-1">
+              <div className="flex items-baseline justify-between gap-2 text-sm">
+                <span className="font-medium">
+                  {formatSingleEnumOption(row.type)}
+                </span>
+                <span className="text-muted-foreground tabular-nums">
+                  {row.count} · {percent.toFixed(1)}%
+                </span>
+              </div>
+              <div className="bg-muted h-2.5 w-full overflow-hidden rounded-full">
+                <div
+                  className={cn(
+                    "h-full rounded-full",
+                    row.isLive
+                      ? "bg-green-500 dark:bg-green-400"
+                      : "bg-zinc-400 dark:bg-zinc-500",
+                  )}
+                  style={{ width: `${width}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="text-muted-foreground flex flex-wrap items-center gap-4 text-xs">
+        <LegendSwatch className="bg-green-500 dark:bg-green-400" label="Live outcome" />
+        <LegendSwatch className="bg-zinc-400 dark:bg-zinc-500" label="Non-live outcome" />
+      </div>
+    </div>
+  );
+}
+
+function LegendSwatch({ className, label }: { className: string; label: string }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      <span className={cn("size-2.5 rounded-sm", className)} />
+      {label}
+    </span>
+  );
+}

--- a/components/dashboard/reports/overview-cards.tsx
+++ b/components/dashboard/reports/overview-cards.tsx
@@ -1,0 +1,197 @@
+import Link from "next/link";
+import { IconArrowUpRight } from "@tabler/icons-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardAction,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatSingleEnumOption } from "@/app/lib/utils/enum-formatter";
+import {
+  fetchBalanceSummary,
+  fetchIntakeSummary,
+  fetchLengthOfStaySummary,
+  fetchOutcomeSummary,
+} from "@/app/lib/data/reports/reports-overview.data";
+
+// Raw URL params flowed down to each card so it can run its own fetch (letting
+// the cards stream independently) and build a link that preserves the range.
+export type OverviewCardParams = {
+  from?: string;
+  to?: string;
+  species?: string;
+};
+
+/** Builds a detail-report href that carries the current range/species params. */
+function reportHref(base: string, { from, to, species }: OverviewCardParams) {
+  const params = new URLSearchParams();
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  if (species) params.set("species", species);
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
+}
+
+/**
+ * Shared card presentation. When `href` is set the whole card is a link with a
+ * hover affordance; the balance card omits it (informational only).
+ */
+function ReportCard({
+  label,
+  headline,
+  sub,
+  badges,
+  href,
+}: {
+  label: string;
+  headline: string;
+  sub?: string;
+  badges: string[];
+  href?: string;
+}) {
+  const card = (
+    <Card
+      className={`@container/card h-full ${href ? "transition-colors hover:border-primary/40" : ""}`}
+    >
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="text-2xl tabular-nums @[250px]/card:text-3xl">
+          {headline}
+        </CardTitle>
+        {href && (
+          <CardAction>
+            <IconArrowUpRight className="size-4 text-muted-foreground" />
+          </CardAction>
+        )}
+      </CardHeader>
+      <CardFooter className="flex-col items-start gap-2 text-sm">
+        {sub && <div className="text-muted-foreground">{sub}</div>}
+        {badges.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {badges.map((badge) => (
+              <Badge key={badge} variant="outline" className="font-normal">
+                {badge}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardFooter>
+    </Card>
+  );
+
+  if (!href) return card;
+  return (
+    <Link href={href} className="block h-full">
+      {card}
+    </Link>
+  );
+}
+
+/** Live release rate + top outcome types. Links to the outcomes detail report. */
+export async function OutcomeStatisticsCard(params: OverviewCardParams) {
+  const { total, liveReleaseRate, topTypes } = await fetchOutcomeSummary(
+    params.from,
+    params.to,
+    params.species,
+  );
+
+  return (
+    <ReportCard
+      href={reportHref("/dashboard/reports/outcomes", params)}
+      label="Outcome statistics"
+      headline={`${(liveReleaseRate * 100).toFixed(1)}%`}
+      sub={
+        total === 0
+          ? "No outcomes in this period"
+          : `Live release rate · ${total} total outcomes`
+      }
+      badges={topTypes.map(
+        (t) => `${formatSingleEnumOption(t.type)} · ${t.count}`,
+      )}
+    />
+  );
+}
+
+/** Intakes in / outcomes out with the net balance. Informational (no link). */
+export async function IntakeVsOutcomeCard(params: OverviewCardParams) {
+  const { intakes, outcomes, net } = await fetchBalanceSummary(
+    params.from,
+    params.to,
+    params.species,
+  );
+
+  const netLabel = `Net ${net >= 0 ? "+" : "−"}${Math.abs(net)} in care over period`;
+
+  return (
+    <ReportCard
+      label="Intake vs outcome"
+      headline={`${intakes} in / ${outcomes} out`}
+      sub={netLabel}
+      badges={[]}
+    />
+  );
+}
+
+/** Median LOS plus in-care worklist counts. Links to the LOS detail report. */
+export async function LengthOfStayCard(params: OverviewCardParams) {
+  const { medianDays, inCareNow, over90 } = await fetchLengthOfStaySummary(
+    params.from,
+    params.to,
+    params.species,
+  );
+
+  return (
+    <ReportCard
+      href={reportHref("/dashboard/reports/length-of-stay", params)}
+      label="Length of stay"
+      headline={medianDays === null ? "—" : `${medianDays} days`}
+      sub="Median · completed stays in period"
+      badges={[`${over90} over 90 days`, `${inCareNow} in care now`]}
+    />
+  );
+}
+
+/** Total intakes + top intake types. Links to the intakes detail report. */
+export async function IntakeSourcesCard(params: OverviewCardParams) {
+  const { total, topTypes } = await fetchIntakeSummary(
+    params.from,
+    params.to,
+    params.species,
+  );
+
+  return (
+    <ReportCard
+      href={reportHref("/dashboard/reports/intakes", params)}
+      label="Intake sources"
+      headline={`${total}`}
+      sub="Total intakes"
+      badges={topTypes.map(
+        (t) => `${formatSingleEnumOption(t.type)} · ${t.count}`,
+      )}
+    />
+  );
+}
+
+/** Per-card skeleton shown while an individual card's query is in flight. */
+export function OverviewCardSkeleton() {
+  return (
+    <Card className="@container/card h-full">
+      <CardHeader>
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="mt-1 h-8 w-24" />
+      </CardHeader>
+      <CardFooter className="flex-col items-start gap-2">
+        <Skeleton className="h-4 w-40" />
+        <div className="flex gap-1.5">
+          <Skeleton className="h-5 w-20 rounded-md" />
+          <Skeleton className="h-5 w-20 rounded-md" />
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/components/dashboard/reports/report-range-picker.tsx
+++ b/components/dashboard/reports/report-range-picker.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import { format } from "date-fns";
+import { type DateRange } from "react-day-picker";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { IconCalendar } from "@tabler/icons-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+/**
+ * Parses a `yyyy-MM-dd` label into a local calendar `Date` (midnight). Built
+ * from explicit y/m/d parts so it round-trips through `format(..,"yyyy-MM-dd")`
+ * regardless of the viewer's timezone. Returns `undefined` when malformed.
+ */
+function parseYmd(value: string | null): Date | undefined {
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return undefined;
+  const [y, m, d] = value.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+/**
+ * Popover date-range control. Writes `from`/`to` (`yyyy-MM-dd`) into the URL
+ * via `router.replace`, preserving every other param (species, etc.). A
+ * "Year to date" action clears both, letting the server fall back to the
+ * default range.
+ */
+export function ReportRangePicker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { replace } = useRouter();
+  const [open, setOpen] = React.useState(false);
+
+  const fromDate = parseYmd(searchParams.get("from"));
+  const toDate = parseYmd(searchParams.get("to"));
+
+  const selected: DateRange | undefined =
+    fromDate || toDate ? { from: fromDate, to: toDate } : undefined;
+
+  const applyRange = (range: DateRange | undefined) => {
+    const params = new URLSearchParams(searchParams);
+    if (range?.from) params.set("from", format(range.from, "yyyy-MM-dd"));
+    else params.delete("from");
+    if (range?.to) params.set("to", format(range.to, "yyyy-MM-dd"));
+    else params.delete("to");
+    replace(`${pathname}?${params.toString()}`);
+  };
+
+  const resetToYearToDate = () => {
+    const params = new URLSearchParams(searchParams);
+    params.delete("from");
+    params.delete("to");
+    replace(`${pathname}?${params.toString()}`);
+    setOpen(false);
+  };
+
+  const triggerLabel =
+    fromDate && toDate
+      ? `${format(fromDate, "MMM d, yyyy")} – ${format(toDate, "MMM d, yyyy")}`
+      : fromDate
+        ? `From ${format(fromDate, "MMM d, yyyy")}`
+        : toDate
+          ? `Until ${format(toDate, "MMM d, yyyy")}`
+          : "Year to date";
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-8 border-dashed">
+          <IconCalendar className="mr-2 h-4 w-4" />
+          {triggerLabel}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="range"
+          selected={selected}
+          onSelect={applyRange}
+          numberOfMonths={2}
+          defaultMonth={fromDate ?? toDate}
+          autoFocus
+        />
+        <div className="border-t p-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="w-full justify-center"
+            onClick={resetToYearToDate}
+          >
+            Year to date
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.545.0",
         "next": "16.2.6",
         "next-auth": "^5.0.0-beta.28",
@@ -6186,6 +6187,15 @@
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
     },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -9663,7 +9673,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.545.0",
     "next": "16.2.6",
     "next-auth": "^5.0.0-beta.28",


### PR DESCRIPTION
## Summary

Adds a dedicated `/dashboard/reports` section for historical and compliance
reporting, separate from the operational dashboard. All reports are read-only
aggregations over existing intake/outcome data.

## What's included

- **Reports overview**: a launchpad with four live summary cards (outcomes,
  intake vs outcome balance, length of stay, intake sources), each linking to
  a detail report. Cards stream independently via Suspense.
- **Outcome statistics**: live release rate (Shelter Animals Count
  convention: adoption + return-to-owner + transfer-out ÷ total outcomes),
  outcome-by-type breakdown, and methodology note.
- **Intake sources**: intake-by-type breakdown, monthly trend, and top
  source partners for transfers.
- **Length of stay**: median over completed stays in the period, a
  stay-length histogram, and a "longest current stays" worklist for animals
  still in care.

## Key implementation details

- **Date ranges** are URL params (`from`/`to`), defaulting to year-to-date,
  capped at 731 days, and computed in a single configured shelter timezone
  (`SHELTER_TIMEZONE`) via `date-fns-tz`. So every viewer sees identical
  numbers regardless of their own timezone.
- **"In care" and length of stay** are derived by pairing each animal's
  intake/outcome events (`computeStays`), not from `listingStatus`. This
  correctly handles re-intakes and cumulative stay time. Length of stay is
  tracked three ways: per-stay, current, and cumulative.
- **Permission**: new `reports:read`, granted to volunteer and above.
- **Nav**: promoted the Reports entry into the main sidebar.

## Notes

- CSV/PDF export is intentionally deferred (header leaves room for it).
- Adoption-funnel reporting is deferred to a later phase.