### PR TITLE
chore: remove unimplemented AnimalLegalStatus

### DIFF
--- a/app/lib/data/analytics.data.ts
+++ b/app/lib/data/analytics.data.ts
@@ -1,7 +1,6 @@
 import { prisma } from "@/app/lib/prisma";
 import {
   AnimalHealthStatus,
-  AnimalLegalStatus,
   AnimalListingStatus,
   OutcomeType,
   Prisma,
@@ -319,7 +318,6 @@ type AnimalForAttentionQueryPayload = Prisma.AnimalGetPayload<{
     id: true;
     name: true;
     healthStatus: true;
-    legalStatus: true;
     intake: {
       select: {
         intakeDate: true;
@@ -341,18 +339,9 @@ const _fetchAnimalsRequiringAttention = async (): Promise<
   try {
     const animals = await prisma.animal.findMany({
       where: {
-        OR: [
-          {
-            healthStatus: {
-              not: AnimalHealthStatus.HEALTHY,
-            },
-          },
-          {
-            legalStatus: {
-              not: AnimalLegalStatus.NONE,
-            },
-          },
-        ],
+        healthStatus: {
+          not: AnimalHealthStatus.HEALTHY,
+        },
       },
       take: 10,
       orderBy: {
@@ -362,7 +351,6 @@ const _fetchAnimalsRequiringAttention = async (): Promise<
         id: true,
         name: true,
         healthStatus: true,
-        legalStatus: true,
         intake: {
           select: {
             intakeDate: true,
@@ -381,7 +369,6 @@ const _fetchAnimalsRequiringAttention = async (): Promise<
         id: animal.id,
         name: animal.name,
         healthStatus: animal.healthStatus,
-        legalStatus: animal.legalStatus,
         intakeDate: animal.intake[0].intakeDate,
       }));
   } catch (error) {

--- a/app/lib/data/animals/animal.data.ts
+++ b/app/lib/data/animals/animal.data.ts
@@ -124,7 +124,6 @@ const _fetchSectionCardsAnimalData = async (
         city: true,
         state: true,
         healthStatus: true,
-        legalStatus: true,
         animalImages: {
           select: {
             url: true,

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -57,7 +57,6 @@ export type AnimalSectionCardPayload = Prisma.AnimalGetPayload<{
     city: true;
     state: true;
     healthStatus: true;
-    legalStatus: true;
     animalImages: {
       select: {
         url: true;

--- a/components/dashboard/analytics/tables/animal-health/recent-health-columns.tsx
+++ b/components/dashboard/analytics/tables/animal-health/recent-health-columns.tsx
@@ -40,19 +40,6 @@ export const healthColumns: ColumnDef<AnimalsRequiringAttentionPayload>[] = [
     },
   },
   {
-    accessorKey: "legalStatus",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Legal Status" />
-    ),
-    meta: {
-      displayName: "Legal Status",
-    },
-    cell: ({ row }) => {
-      const status = row.getValue("legalStatus") as string;
-      return <Badge variant="outline">{formatSingleEnumOption(status)}</Badge>;
-    },
-  },
-  {
     accessorKey: "intakeDate",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Intake Date" />

--- a/components/dashboard/animals/animal-section-cards.tsx
+++ b/components/dashboard/animals/animal-section-cards.tsx
@@ -330,14 +330,6 @@ const AnimalSectionCards = async ({ params }: Props) => {
                       : formatSingleEnumOption(animal.healthStatus)}
                   </span>
                 </div>
-                <div className="flex items-center justify-between border-b pb-2 text-sm">
-                  <span className="text-muted-foreground">Legal Status</span>
-                  <span className="font-medium">
-                    {animal.legalStatus === "NONE" || !animal.legalStatus
-                      ? "Clear"
-                      : formatSingleEnumOption(animal.legalStatus)}
-                  </span>
-                </div>
               </div>
             </div>
 

--- a/prisma/migrations/20260713232612_remove_animal_legal_status/migration.sql
+++ b/prisma/migrations/20260713232612_remove_animal_legal_status/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "animals" DROP COLUMN "legalStatus";
+
+-- DropEnum
+DROP TYPE "AnimalLegalStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -332,15 +332,6 @@ enum AnimalListingStatus {
   ARCHIVED // Profile is no longer public (e.g., animal adopted, transferred, or otherwise unavailable) and is kept for records.
 }
 
-enum AnimalLegalStatus {
-  NONE
-  STRAY_HOLD
-  BITE_QUARANTINE
-  COURT_HOLD
-  POLICE_HOLD
-  PROTECTIVE_CUSTODY
-}
-
 enum CharacteristicCategory {
   BEHAVIOR // For behavioral notes like "Bite History", "On-Leash Reactivity"
   MEDICAL // For health-related tags like "Deaf", "Heartworm Positive"
@@ -383,8 +374,7 @@ model Animal {
   Outcome              Outcome[]
   activityLog          AnimalActivityLog[]
   healthStatus         AnimalHealthStatus?
-  legalStatus          AnimalLegalStatus?    @default(NONE)
-  //  This is a "denormalized" field that you would update to true after a 
+  //  This is a "denormalized" field that you would update to true after a
   // MedicalRecord for the procedure is created. It makes sorting and filtering trivial.
 
   // denormalized flags to animal

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,7 +7,6 @@ import {
   AnimalListingStatus,
   IntakeType,
   AnimalHealthStatus,
-  AnimalLegalStatus,
   NoteCategory,
   TaskCategory,
   TaskPriority,
@@ -443,7 +442,6 @@ interface AnimalBlueprint {
   archetype: Archetype;
   intakeType: IntakeType;
   healthStatus: AnimalHealthStatus;
-  legalStatus: AnimalLegalStatus;
   listingStatus: AnimalListingStatus;
   // A minority of open stays run long (90-160 days) so the length-of-stay
   // report's "over 90 days" bucket has real entries.
@@ -470,7 +468,6 @@ const animalSeedData: AnimalBlueprint[] = [
     ],
     intakeType: IntakeType.OWNER_SURRENDER,
     healthStatus: AnimalHealthStatus.HEALTHY,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [`${baseUrl}/dog1.jpg`, `${baseUrl}/dog1-1.webp`],
     unitName: allLocations.DOG_BLOCK_A.units.A1.name,
     archetype: "IN_CARE",
@@ -492,7 +489,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [allCharacteristics.NEEDS_QUIET_HOME],
     intakeType: IntakeType.STRAY,
     healthStatus: AnimalHealthStatus.AWAITING_VET_EXAM,
-    legalStatus: AnimalLegalStatus.STRAY_HOLD,
     images: [`${baseUrl}/dog2.jpg`, `${baseUrl}/dog2-1.webp`],
     unitName: allLocations.DOG_BLOCK_A.units.A2.name,
     archetype: "IN_CARE",
@@ -511,7 +507,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [allCharacteristics.HOUSEBROKEN],
     intakeType: IntakeType.TRANSFER_IN,
     healthStatus: AnimalHealthStatus.UNDER_VET_CARE,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [`${baseUrl}/dog3.jpg`, `${baseUrl}/dog3-1.jpg`],
     unitName: allLocations.MEDICAL_WING.units.MED1.name,
     archetype: "IN_CARE",
@@ -530,7 +525,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [allCharacteristics.GOOD_WITH_CATS],
     intakeType: IntakeType.OWNER_SURRENDER,
     healthStatus: AnimalHealthStatus.HEALTHY,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [
       `${baseUrl}/cat1.webp`,
       `${baseUrl}/cat1-1.jpg`,
@@ -553,7 +547,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [],
     intakeType: IntakeType.BORN_IN_CARE,
     healthStatus: AnimalHealthStatus.AWAITING_SPAY_NEUTER,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [
       `${baseUrl}/cat2.webp`,
       `${baseUrl}/cat2-1.jpg`,
@@ -576,7 +569,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [],
     intakeType: IntakeType.SEIZE,
     healthStatus: AnimalHealthStatus.AWAITING_TRIAGE,
-    legalStatus: AnimalLegalStatus.POLICE_HOLD,
     images: [
       `${baseUrl}/reptile2.webp`,
       `${baseUrl}/reptile2-1.jpg`,
@@ -602,7 +594,6 @@ const animalSeedData: AnimalBlueprint[] = [
     ],
     intakeType: IntakeType.STRAY,
     healthStatus: AnimalHealthStatus.HEALTHY,
-    legalStatus: AnimalLegalStatus.STRAY_HOLD,
     images: [`${baseUrl}/dog3-2.webp`],
     unitName: allLocations.DOG_BLOCK_A.units.A3.name,
     archetype: "IN_CARE",
@@ -624,7 +615,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [allCharacteristics.GOOD_WITH_CATS],
     intakeType: IntakeType.BORN_IN_CARE,
     healthStatus: AnimalHealthStatus.HEALTHY,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [`${baseUrl}/dog1-3.webp`],
     // Unplaced: not yet assigned to a unit (shows in the "Unplaced" column).
     unitName: null,
@@ -645,7 +635,6 @@ const animalSeedData: AnimalBlueprint[] = [
     characteristics: [allCharacteristics.DEAF],
     intakeType: IntakeType.TRANSFER_IN,
     healthStatus: AnimalHealthStatus.UNDER_VET_CARE,
-    legalStatus: AnimalLegalStatus.NONE,
     images: [`${baseUrl}/dog1-2.jpg`],
     unitName: allLocations.MEDICAL_WING.units.MED2.name,
     archetype: "IN_CARE",
@@ -899,23 +888,6 @@ function pickHealthStatus(): AnimalHealthStatus {
   ]);
 }
 
-function pickLegalStatus(intakeType: IntakeType): AnimalLegalStatus {
-  if (intakeType === IntakeType.STRAY && Math.random() < 0.3) {
-    return AnimalLegalStatus.STRAY_HOLD;
-  }
-  if (intakeType === IntakeType.SEIZE && Math.random() < 0.5) {
-    return getRandomItem([
-      AnimalLegalStatus.POLICE_HOLD,
-      AnimalLegalStatus.COURT_HOLD,
-      AnimalLegalStatus.PROTECTIVE_CUSTODY,
-    ]);
-  }
-  if (intakeType === IntakeType.ACO_IMPOUND && Math.random() < 0.2) {
-    return AnimalLegalStatus.BITE_QUARANTINE;
-  }
-  return AnimalLegalStatus.NONE;
-}
-
 function pickBreeds(
   species: (typeof allSpecies)[keyof typeof allSpecies],
 ): { name: string }[] {
@@ -1068,7 +1040,6 @@ function generateAnimalBlueprints(
       archetype,
       intakeType,
       healthStatus: pickHealthStatus(),
-      legalStatus: pickLegalStatus(intakeType),
       listingStatus: isDraft
         ? AnimalListingStatus.DRAFT
         : AnimalListingStatus.PUBLISHED,
@@ -1507,7 +1478,6 @@ async function seedReturnAndReadoptAnimal(opts: {
       listingStatus: AnimalListingStatus.PUBLISHED,
       publishedAt: stay1.intakeDate,
       healthStatus: blueprint.healthStatus,
-      legalStatus: blueprint.legalStatus,
       species: { connect: { id: species.id } },
       breeds: { connect: connectedBreeds },
       colors: { connect: connectedColors },
@@ -1567,7 +1537,7 @@ async function seedReturnAndReadoptAnimal(opts: {
   });
 
   // Re-intake: mirrors `_createReIntake` — a new Intake event, the animal's
-  // prior archive reason is cleared, and a fresh health/legal status is set.
+  // prior archive reason is cleared, and a fresh health status is set.
   const reIntakeType = pickWeighted([
     { value: IntakeType.OWNER_SURRENDER, weight: 70 },
     { value: IntakeType.STRAY, weight: 20 },
@@ -1594,7 +1564,6 @@ async function seedReturnAndReadoptAnimal(opts: {
     where: { id: animal.id },
     data: {
       healthStatus: reIntakeHealthStatus,
-      legalStatus: AnimalLegalStatus.NONE,
     },
   });
 
@@ -2009,7 +1978,6 @@ async function seedAnimalsAndRelations() {
           listingStatus: interimListingStatus,
           publishedAt: stay.intakeDate,
           healthStatus: blueprint.healthStatus,
-          legalStatus: blueprint.legalStatus,
           species: { connect: { id: species.id } },
           breeds: { connect: connectedBreeds },
           colors: { connect: connectedColors },
@@ -2495,7 +2463,6 @@ async function seedFostering() {
         listingStatus: AnimalListingStatus.PUBLISHED,
         publishedAt: intakeDate,
         healthStatus: AnimalHealthStatus.HEALTHY,
-        legalStatus: AnimalLegalStatus.NONE,
         species: { connect: { id: dogSpecies.id } },
         breeds: { connect: [{ id: breed.id }] },
         colors: { connect: [{ id: primaryColor.id }] },


### PR DESCRIPTION
## What

Removes `AnimalLegalStatus` (enum + `Animal.legalStatus` field) from the schema, seed, and UI. This was a placeholder added early on, but it was never implemented as a real feature, no create/edit form, no workflow logic, no guards. It only ever showed up as seeded display data with a "Legal Status" row on the animal profile.

## Why

Cleaning this up before starting the medical schema rework (WeightEntry →
MedicalRecord → Vaccination → DiagnosticTest → MedicationSchedule/Log)

Legal status as a concept isn't going away for good, a proper `AnimalHold`
model (dated hold events with `expiresAt`/`releasedAt`, blocking outcomes and
publishing while active) is documented in the feature roadmap for whenever
there's a real municipal/animal-control use case driving it. This PR is just
removing the placeholder, not designing the replacement.